### PR TITLE
fix(favicon): drop 🔮 from favicon (dedup with title)

### DIFF
--- a/apps/canvas/index.html
+++ b/apps/canvas/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔮</text></svg>">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%23101020'/><text x='50' y='72' font-size='62' font-family='system-ui' font-weight='700' fill='%23a78bfa' text-anchor='middle'>A</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ARRA 🔮Racle — Canvas</title>
   </head>

--- a/apps/studio/index.html
+++ b/apps/studio/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔮</text></svg>">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%23101020'/><text x='50' y='72' font-size='62' font-family='system-ui' font-weight='700' fill='%23a78bfa' text-anchor='middle'>A</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ARRA 🔮Racle</title>
   </head>

--- a/apps/vector/index.html
+++ b/apps/vector/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔮</text></svg>">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%23101020'/><text x='50' y='72' font-size='62' font-family='system-ui' font-weight='700' fill='%23a78bfa' text-anchor='middle'>A</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ARRA 🔮Racle — Vector</title>
   </head>


### PR DESCRIPTION
Browser tab was showing two 🔮. Favicon becomes branded A.