### PR TITLE
fix(ui): PageShell sweep — top 5 pages per app

### DIFF
--- a/apps/canvas/src/pages/CanvasHost.tsx
+++ b/apps/canvas/src/pages/CanvasHost.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
+import { PageShell } from '@ui-oracle/shared-ui';
 import { findPlugin, listPlugins } from '../lib/plugins/registry';
 
 export default function CanvasHost() {
@@ -13,7 +14,7 @@ export default function CanvasHost() {
   const all = listPlugins();
 
   return (
-    <main className="max-w-[1400px] mx-auto px-4 py-10 text-text-primary">
+    <PageShell className="text-text-primary">
       <h1 className="text-2xl font-semibold mb-3">Canvas host — phase 1 scaffold</h1>
       <p className="text-text-secondary mb-6">
         Plugin: <code className="bg-bg-card px-2 py-0.5 rounded">{pluginId ?? '(none — pass ?plugin=<id>)'}</code>
@@ -48,6 +49,6 @@ export default function CanvasHost() {
           </ul>
         )}
       </section>
-    </main>
+    </PageShell>
   );
 }

--- a/apps/studio/src/pages/Forum.tsx
+++ b/apps/studio/src/pages/Forum.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { PageShell } from '@ui-oracle/shared-ui';
 import { Spinner } from '../components/ui/Spinner';
 import { API_BASE } from '../api/oracle';
 
@@ -93,8 +94,9 @@ export function Forum() {
   }
 
   return (
-    <div className="flex max-w-[1300px] mx-auto py-6 px-6 gap-6 max-md:flex-col max-md:p-3 max-md:gap-0">
-      {/* Sidebar — hidden on mobile when thread is selected */}
+    <PageShell>
+      <div className="flex gap-6 max-md:flex-col max-md:gap-0">
+        {/* Sidebar — hidden on mobile when thread is selected */}
       <div className={`w-[180px] shrink-0 flex flex-col max-md:w-full ${selected ? 'max-md:hidden' : ''}`}>
         <div className="flex justify-between items-center mb-3">
           <h2 className="text-xs font-mono uppercase tracking-wide text-text-muted">Threads</h2>
@@ -213,7 +215,8 @@ export function Forum() {
           </div>
         )}
       </div>
-    </div>
+      </div>
+    </PageShell>
   );
 }
 

--- a/apps/studio/src/pages/Overview.tsx
+++ b/apps/studio/src/pages/Overview.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { PageShell } from '@ui-oracle/shared-ui';
 import { getStats, reflect, stripProjectPrefix } from '../api/oracle';
 import type { Document, Stats } from '../api/oracle';
 
@@ -73,7 +74,7 @@ export function Overview() {
   }
 
   return (
-    <div className="max-w-[900px] mx-auto py-12 px-6">
+    <PageShell maxWidth="900px">
       <style>{wisdomAnimationStyle}</style>
 
       <h1 className="text-4xl font-bold text-text-primary mb-2 text-center">Oracle Overview</h1>
@@ -351,6 +352,6 @@ export function Overview() {
           </a>
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/apps/studio/src/pages/Search.tsx
+++ b/apps/studio/src/pages/Search.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { PageShell } from '@ui-oracle/shared-ui';
 import { search } from '../api/oracle';
 import type { Document } from '../api/oracle';
 import { LogCard } from '../components/LogCard';
@@ -43,7 +44,7 @@ export function Search() {
   }
 
   return (
-    <div className="max-w-[720px] mx-auto py-12 px-6">
+    <PageShell maxWidth="720px">
       <h1 className="text-[32px] font-bold text-text-primary mb-6 text-center">Search Oracle</h1>
 
       <form onSubmit={handleSubmit} className="flex gap-3 mb-8">
@@ -106,6 +107,6 @@ export function Search() {
           </div>
         </div>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/apps/vector/src/pages/Compare.tsx
+++ b/apps/vector/src/pages/Compare.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { PageShell } from '@ui-oracle/shared-ui';
 import type { Document } from '../api/oracle';
 import { getStats } from '../api/oracle';
 import { hostLabel } from '../api/host';
@@ -55,7 +56,7 @@ export default function Compare() {
   const currentHost = hostLabel().replace(' (default)', '');
 
   return (
-    <div className="max-w-[1400px] mx-auto py-6 px-6">
+    <PageShell>
       <CompareHUD
         query={query}
         onQueryChange={setQuery}
@@ -81,6 +82,6 @@ export default function Compare() {
           studioOrigin={STUDIO_ORIGIN}
         />
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/apps/vector/src/pages/Playground.tsx
+++ b/apps/vector/src/pages/Playground.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { PageShell } from '@ui-oracle/shared-ui';
 import { search } from '../api/oracle';
 import type { Document } from '../api/oracle';
 import { demoSearch } from '../data/demo';
@@ -154,7 +155,7 @@ export default function Playground({ backendLive }: { backendLive: boolean }) {
 
       {/* Post-search */}
       {(searched || loading) && (
-        <div className="max-w-[1300px] mx-auto py-6 px-6">
+        <PageShell>
           <form onSubmit={handleSubmit} className="flex max-md:flex-col gap-3 max-w-[720px] mx-auto mb-4">
             <input
               type="text"
@@ -206,7 +207,7 @@ export default function Playground({ backendLive }: { backendLive: boolean }) {
               </div>
             </>
           )}
-        </div>
+        </PageShell>
       )}
 
       {selectedDoc && <DocDrawer doc={selectedDoc} onClose={() => setSelectedDoc(null)} />}


### PR DESCRIPTION
## Summary
Applies shared `PageShell` + playground rhythm to most-visible pages across all 3 apps.

Replaces per-page container divs with `<PageShell>` from `@ui-oracle/shared-ui` so every app picks up the same `max-w-[1300px] mx-auto py-6 px-6` rhythm as the vector `/playground` reference.

**Pages touched (6):**
- `studio`: Overview, Search, Forum
- `vector`: Playground (post-search block), Compare
- `canvas`: CanvasHost

**Skipped (follow-up):**
- `studio/Feed` — uses `SidebarLayout` which owns its container (out of scope)
- `studio/Map` — fullscreen 3D canvas (`h-[calc(100vh-64px)]`); PageShell would break layout

## Test plan
- [x] `bun run build:studio` — green
- [x] `bun run build:vector` — green
- [x] `bun run build:canvas` — green
- [ ] Visual regression via task #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)