### PR TITLE
fix(header): fade nav in on load (kill menu blink)

### DIFF
--- a/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
@@ -75,7 +75,7 @@ export function AppHeader({
   crossOriginHref = defaultCrossOriginHref,
   hideToolsDropdown = false,
 }: AppHeaderProps) {
-  const nav = useMenu(fallbackNav);
+  const { nav, loaded } = useMenu(fallbackNav);
   const backendVersion = useBackendVersion();
 
   return (
@@ -98,7 +98,11 @@ export function AppHeader({
         </div>
       </div>
 
-      <nav className="flex items-center gap-0.5 px-4 pb-2 flex-wrap max-w-[1400px] mx-auto">
+      <nav
+        className={`flex items-center gap-0.5 px-4 pb-2 flex-wrap max-w-[1400px] mx-auto transition-opacity duration-150 ${
+          loaded ? 'opacity-100' : 'opacity-0'
+        }`}
+      >
         <MainNav items={nav.main} crossOriginHref={crossOriginHref} />
         {!hideToolsDropdown && nav.tools.length > 0 && (
           <>

--- a/packages/shared-ui/src/components/AppHeader/use-menu.ts
+++ b/packages/shared-ui/src/components/AppHeader/use-menu.ts
@@ -8,10 +8,13 @@ const MENU_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Load the nav menu from /api/menu with localStorage/idb caching + fallback.
- * Returns the fallback until the fetch completes, then swaps in the server's list.
+ * Returns `{ nav, loaded }` — fallback is kept until the fetch resolves (success
+ * or failure). Callers can gate visibility on `loaded` to avoid a fallback→server
+ * content-jump flash.
  */
-export function useMenu(fallback: NavSet): NavSet {
+export function useMenu(fallback: NavSet): { nav: NavSet; loaded: boolean } {
   const [nav, setNav] = useState<NavSet>(fallback);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -27,11 +30,13 @@ export function useMenu(fallback: NavSet): NavSet {
           },
           { tag: 'menu' },
         );
+        if (cancelled) return;
         const items: MenuApiItem[] = Array.isArray(data?.items) ? data.items : [];
-        if (cancelled || items.length === 0) return;
-        setNav(buildNavSet(items));
+        if (items.length > 0) setNav(buildNavSet(items));
       } catch {
         // Backend unreachable — keep fallback nav.
+      } finally {
+        if (!cancelled) setLoaded(true);
       }
     })();
     return () => {
@@ -39,7 +44,7 @@ export function useMenu(fallback: NavSet): NavSet {
     };
   }, []);
 
-  return nav;
+  return { nav, loaded };
 }
 
 /**


### PR DESCRIPTION
Fallback → server swap was visible. Fade to hide.