### PR TITLE
feat: split Schedule to schedule.buildwithoracle.com

### DIFF
--- a/apps/schedule/.gitignore
+++ b/apps/schedule/.gitignore
@@ -1,0 +1,27 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Cloudflare
+.wrangler
+.dev.vars
+
+# Agent workdirs
+agents/

--- a/apps/schedule/index.html
+++ b/apps/schedule/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%23101020'/><text x='50' y='72' font-size='62' font-family='system-ui' font-weight='700' fill='%23a78bfa' text-anchor='middle'>A</text></svg>">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ARRA 🔮Racle — Schedule</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/schedule/package.json
+++ b/apps/schedule/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "schedule-oracle-studio",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Schedule bundle — schedule.buildwithoracle.com",
+  "engines": {
+    "bun": ">=1.2.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Soul-Brews-Studio/ui-oracle.git"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "deploy": "bun run build && wrangler deploy"
+  },
+  "dependencies": {
+    "@ui-oracle/shared-ui": "workspace:*",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "react-markdown": "^10.1.0",
+    "react-router-dom": "^7.11.0",
+    "remark-gfm": "^4.0.1"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.2.1",
+    "@types/bun": "^1.3.12",
+    "@types/node": "^24.10.1",
+    "@types/react": "^19.2.5",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "tailwindcss": "^4.2.1",
+    "typescript": "~5.9.3",
+    "vite": "^7.2.4"
+  },
+  "author": "Soul Brews Studio",
+  "license": "MIT"
+}

--- a/apps/schedule/src/App.tsx
+++ b/apps/schedule/src/App.tsx
@@ -1,0 +1,15 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Schedule from './pages/Schedule';
+import { Header } from './components/Header';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Header />
+      <Routes>
+        <Route path="/" element={<Schedule />} />
+        <Route path="*" element={<Schedule />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/apps/schedule/src/api/host.ts
+++ b/apps/schedule/src/api/host.ts
@@ -1,0 +1,1 @@
+export * from '@ui-oracle/shared-ui';

--- a/apps/schedule/src/api/oracle.ts
+++ b/apps/schedule/src/api/oracle.ts
@@ -1,0 +1,35 @@
+import { apiUrl } from './host';
+export { apiUrl, hostLabel, activeHost, isDefault, isRemote } from './host';
+
+export const API_BASE = apiUrl('/api');
+
+export async function ping(): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/stats`, { signal: AbortSignal.timeout(2000) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export interface ScheduleEventInput {
+  date: string;
+  event: string;
+  time?: string;
+  notes?: string;
+}
+
+export async function getScheduleMd(): Promise<string> {
+  const res = await fetch(`${API_BASE}/schedule/md`);
+  if (!res.ok) throw new Error(`schedule/md ${res.status}`);
+  return res.text();
+}
+
+export async function addScheduleEvent(body: ScheduleEventInput): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/schedule`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return res.ok;
+}

--- a/apps/schedule/src/components/Header.tsx
+++ b/apps/schedule/src/components/Header.tsx
@@ -1,0 +1,6 @@
+import { AppHeader } from '@ui-oracle/shared-ui';
+import { ping } from '../api/oracle';
+
+export function Header() {
+  return <AppHeader brandLabel="ARRA 🔮Racle — Schedule" ping={ping} />;
+}

--- a/apps/schedule/src/index.css
+++ b/apps/schedule/src/index.css
@@ -1,0 +1,42 @@
+@import "tailwindcss";
+@source "../../../packages/shared-ui/src/**/*.{ts,tsx}";
+
+@theme {
+  --color-bg-primary: #0a0a0f;
+  --color-bg-secondary: #0f0f1a;
+  --color-bg-card: #0f0f14;
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-border-subtle: rgba(255, 255, 255, 0.04);
+  --color-border-hover: rgba(255, 255, 255, 0.12);
+  --color-accent: #64b5f6;
+  --color-accent-hover: #42a5f5;
+  --color-success: #4ade80;
+  --color-warning: #fbbf24;
+  --color-text-primary: #e8e8ee;
+  --color-text-secondary: #9aa0ab;
+  --color-text-muted: #6b7280;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  min-height: 100vh;
+  line-height: 1.6;
+  background-image:
+    radial-gradient(at 15% 10%, rgba(96, 165, 250, 0.10) 0px, transparent 55%),
+    radial-gradient(at 85% 20%, rgba(167, 139, 250, 0.10) 0px, transparent 55%),
+    radial-gradient(at 50% 90%, rgba(74, 222, 128, 0.08) 0px, transparent 60%),
+    linear-gradient(180deg, #07070c 0%, #0a0a10 100%);
+  background-attachment: fixed;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.1); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.2); }
+* { scrollbar-width: thin; scrollbar-color: rgba(255, 255, 255, 0.1) transparent; }

--- a/apps/schedule/src/main.tsx
+++ b/apps/schedule/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/apps/schedule/src/pages/Schedule.tsx
+++ b/apps/schedule/src/pages/Schedule.tsx
@@ -1,0 +1,124 @@
+import { useState, useEffect } from 'react';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { PageShell } from '@ui-oracle/shared-ui';
+import { addScheduleEvent, getScheduleMd } from '../api/oracle';
+
+export default function Schedule() {
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [adding, setAdding] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState({ date: '', event: '', time: '', notes: '' });
+
+  useEffect(() => { void loadSchedule(); }, []);
+
+  async function loadSchedule() {
+    setLoading(true);
+    try {
+      setContent(await getScheduleMd());
+    } catch (e) {
+      console.error('Failed to load schedule:', e);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.date || !form.event) return;
+    setAdding(true);
+    try {
+      const ok = await addScheduleEvent(form);
+      if (ok) {
+        setForm({ date: '', event: '', time: '', notes: '' });
+        setShowForm(false);
+        await loadSchedule();
+      }
+    } catch (e) {
+      console.error('Failed to add event:', e);
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  const inputCls = 'bg-bg-secondary border border-border rounded-lg px-3.5 py-2.5 text-text-primary text-sm flex-1 outline-none focus:border-accent transition-colors duration-150 placeholder:text-text-muted [&::-webkit-search-cancel-button]:hidden [&::-webkit-clear-button]:hidden [&::-ms-clear]:hidden';
+
+  return (
+    <PageShell className="text-text-primary">
+      <div className="flex justify-between items-start mb-6 max-md:flex-col max-md:gap-3">
+        <div>
+          <h1 className="text-[32px] font-bold text-text-primary mb-2">Schedule</h1>
+          <p className="text-text-secondary">
+            <code className="bg-bg-card px-1.5 py-0.5 rounded text-[13px]">~/.oracle/psi/inbox/schedule.md</code>
+          </p>
+        </div>
+        <button
+          className="bg-accent text-black border-none px-4 py-2 rounded-lg text-sm font-medium cursor-pointer whitespace-nowrap hover:opacity-90 transition-opacity duration-150"
+          onClick={() => setShowForm(!showForm)}
+        >
+          {showForm ? 'Cancel' : '+ Add Event'}
+        </button>
+      </div>
+
+      {showForm && (
+        <form onSubmit={handleAdd} className="bg-bg-card border border-border rounded-xl p-5 mb-6 flex flex-col gap-3">
+          <div className="flex gap-3 max-md:flex-col">
+            <input
+              className={inputCls}
+              style={{ WebkitAppearance: 'none' }}
+              placeholder="Date (e.g. 5 Mar, 28 ก.พ.)"
+              value={form.date}
+              onChange={e => setForm({ ...form, date: e.target.value })}
+              required
+            />
+            <input
+              className={inputCls}
+              style={{ WebkitAppearance: 'none' }}
+              placeholder="Time (e.g. 14:00, TBD)"
+              value={form.time}
+              onChange={e => setForm({ ...form, time: e.target.value })}
+            />
+          </div>
+          <input
+            className={inputCls}
+            style={{ WebkitAppearance: 'none' }}
+            placeholder="Event description"
+            value={form.event}
+            onChange={e => setForm({ ...form, event: e.target.value })}
+            required
+          />
+          <input
+            className={inputCls}
+            style={{ WebkitAppearance: 'none' }}
+            placeholder="Notes (optional)"
+            value={form.notes}
+            onChange={e => setForm({ ...form, notes: e.target.value })}
+          />
+          <button
+            type="submit"
+            className="bg-accent text-black border-none px-5 py-2.5 rounded-lg text-sm font-medium cursor-pointer self-end disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={adding}
+          >
+            {adding ? 'Adding...' : 'Add to Schedule'}
+          </button>
+        </form>
+      )}
+
+      {loading ? (
+        <div className="text-text-muted py-12 text-center">Loading schedule...</div>
+      ) : content ? (
+        <div className="bg-bg-card border border-border rounded-xl p-6 leading-[1.7] text-text-primary text-sm [&_h1]:my-4 [&_h1]:mb-2 [&_h1]:text-xl [&_h1]:text-text-primary [&_h2]:my-4 [&_h2]:mb-2 [&_h2]:text-[17px] [&_h2]:text-text-primary [&_h3]:my-4 [&_h3]:mb-2 [&_h3]:text-[15px] [&_h3]:text-text-primary [&_p]:my-2 [&_table]:w-full [&_table]:border-collapse [&_table]:my-3 [&_th]:text-left [&_th]:px-3 [&_th]:py-2 [&_th]:border-b [&_th]:border-border [&_th]:text-xs [&_th]:text-text-muted [&_th]:font-semibold [&_th]:uppercase [&_th]:tracking-wide [&_td]:text-left [&_td]:px-3 [&_td]:py-2 [&_td]:border-b [&_td]:border-border [&_td]:text-[13px] [&_td]:text-text-primary [&_strong]:text-accent [&_hr]:border-none [&_hr]:border-t [&_hr]:border-border [&_hr]:my-4">
+          <Markdown remarkPlugins={[remarkGfm]}>{content}</Markdown>
+        </div>
+      ) : (
+        <div className="text-center py-16 text-text-secondary">
+          <p className="my-2">No schedule found.</p>
+          <p className="text-sm text-text-muted my-2">
+            Use <code className="bg-bg-card px-1.5 py-0.5 rounded text-[13px]">oracle_schedule_add</code> or click "+ Add Event".
+          </p>
+        </div>
+      )}
+    </PageShell>
+  );
+}

--- a/apps/schedule/src/vite-env.d.ts
+++ b/apps/schedule/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/apps/schedule/tsconfig.app.json
+++ b/apps/schedule/tsconfig.app.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "types": ["vite/client", "bun"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/apps/schedule/tsconfig.json
+++ b/apps/schedule/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/apps/schedule/tsconfig.node.json
+++ b/apps/schedule/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/schedule/vite.config.ts
+++ b/apps/schedule/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'))
+const gitHash = (() => {
+  try { return execSync('git rev-parse --short HEAD').toString().trim() }
+  catch { return 'dev' }
+})()
+const appVersion = `v${pkg.version}+${gitHash}`
+
+export default defineConfig({
+  plugins: [tailwindcss(), react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
+  server: {
+    port: 5173,
+    allowedHosts: true,
+  },
+})

--- a/apps/schedule/worker.ts
+++ b/apps/schedule/worker.ts
@@ -1,0 +1,28 @@
+interface Env {
+  ASSETS: { fetch: (request: Request) => Promise<Response> };
+}
+
+// Hashed by Vite — safe to cache forever. Covers /assets/* and *-[hash].{js,css,png,woff2,...}
+const HASHED_ASSET = /\/(?:assets\/|[^/]+-)[A-Za-z0-9_-]{8,}\.[a-z0-9]+$/i;
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const response = await env.ASSETS.fetch(request);
+    if (!response.ok) return response;
+
+    const headers = new Headers(response.headers);
+
+    if (HASHED_ASSET.test(url.pathname)) {
+      headers.set("cache-control", "public, max-age=31536000, immutable");
+    } else {
+      headers.set("cache-control", "public, max-age=3600, stale-while-revalidate=86400");
+    }
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  },
+};

--- a/apps/schedule/wrangler.json
+++ b/apps/schedule/wrangler.json
@@ -1,0 +1,19 @@
+{
+  "name": "schedule-oracle-studio",
+  "main": "worker.ts",
+  "compatibility_date": "2025-06-01",
+  "account_id": "a5eabdc2b11aae9bd5af46bd6a88179e",
+  "workers_dev": true,
+  "routes": [
+    {
+      "pattern": "schedule.buildwithoracle.com",
+      "custom_domain": true
+    }
+  ],
+  "assets": {
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
+  }
+}

--- a/apps/studio/src/pages/Schedule.tsx
+++ b/apps/studio/src/pages/Schedule.tsx
@@ -1,127 +1,17 @@
-import { useState, useEffect } from 'react';
-import Markdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { SidebarLayout, TOOLS_NAV } from '../components/SidebarLayout';
-import { API_BASE } from '../api/oracle';
+import { useEffect } from 'react';
+import { hostLabel } from '@ui-oracle/shared-ui';
+
+const SCHEDULE_ORIGIN = 'https://schedule.buildwithoracle.com';
 
 export function Schedule() {
-  const [content, setContent] = useState('');
-  const [loading, setLoading] = useState(true);
-  const [adding, setAdding] = useState(false);
-  const [showForm, setShowForm] = useState(false);
-  const [form, setForm] = useState({ date: '', event: '', time: '', notes: '' });
-
-  useEffect(() => { loadSchedule(); }, []);
-
-  async function loadSchedule() {
-    setLoading(true);
-    try {
-      const res = await fetch(`${API_BASE}/schedule/md`);
-      if (res.ok) setContent(await res.text());
-    } catch (e) {
-      console.error('Failed to load schedule:', e);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleAdd(e: React.FormEvent) {
-    e.preventDefault();
-    if (!form.date || !form.event) return;
-    setAdding(true);
-    try {
-      const res = await fetch(`${API_BASE}/schedule`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
-      });
-      if (res.ok) {
-        setForm({ date: '', event: '', time: '', notes: '' });
-        setShowForm(false);
-        await loadSchedule();
-      }
-    } catch (e) {
-      console.error('Failed to add event:', e);
-    } finally {
-      setAdding(false);
-    }
-  }
+  useEffect(() => {
+    const currentHost = hostLabel().replace(' (default)', '');
+    window.location.replace(`${SCHEDULE_ORIGIN}/?host=${encodeURIComponent(currentHost)}`);
+  }, []);
 
   return (
-    <SidebarLayout navItems={TOOLS_NAV} navTitle="Tools" filters={[]}>
-      <div className="flex justify-between items-start mb-6 max-md:flex-col max-md:gap-3">
-        <div>
-          <h1 className="text-[32px] font-bold text-text-primary mb-2">Schedule</h1>
-          <p className="text-text-secondary">
-            <code className="bg-bg-card px-1.5 py-0.5 rounded text-[13px]">~/.oracle/psi/inbox/schedule.md</code>
-          </p>
-        </div>
-        <button
-          className="bg-accent text-black border-none px-4 py-2 rounded-lg text-sm font-medium cursor-pointer whitespace-nowrap hover:opacity-90 transition-opacity duration-150"
-          onClick={() => setShowForm(!showForm)}
-        >
-          {showForm ? 'Cancel' : '+ Add Event'}
-        </button>
-      </div>
-
-      {showForm && (
-        <form onSubmit={handleAdd} className="bg-bg-card border border-border rounded-xl p-5 mb-6 flex flex-col gap-3">
-          <div className="flex gap-3 max-md:flex-col">
-            <input
-              className="bg-bg-secondary border border-border rounded-lg px-3.5 py-2.5 text-text-primary text-sm flex-1 outline-none focus:border-accent transition-colors duration-150 placeholder:text-text-muted [&::-webkit-search-cancel-button]:hidden [&::-webkit-clear-button]:hidden [&::-ms-clear]:hidden"
-              style={{ WebkitAppearance: 'none' }}
-              placeholder="Date (e.g. 5 Mar, 28 ก.พ.)"
-              value={form.date}
-              onChange={e => setForm({ ...form, date: e.target.value })}
-              required
-            />
-            <input
-              className="bg-bg-secondary border border-border rounded-lg px-3.5 py-2.5 text-text-primary text-sm flex-1 outline-none focus:border-accent transition-colors duration-150 placeholder:text-text-muted [&::-webkit-search-cancel-button]:hidden [&::-webkit-clear-button]:hidden [&::-ms-clear]:hidden"
-              style={{ WebkitAppearance: 'none' }}
-              placeholder="Time (e.g. 14:00, TBD)"
-              value={form.time}
-              onChange={e => setForm({ ...form, time: e.target.value })}
-            />
-          </div>
-          <input
-            className="bg-bg-secondary border border-border rounded-lg px-3.5 py-2.5 text-text-primary text-sm flex-1 outline-none focus:border-accent transition-colors duration-150 placeholder:text-text-muted [&::-webkit-search-cancel-button]:hidden [&::-webkit-clear-button]:hidden [&::-ms-clear]:hidden"
-            style={{ WebkitAppearance: 'none' }}
-            placeholder="Event description"
-            value={form.event}
-            onChange={e => setForm({ ...form, event: e.target.value })}
-            required
-          />
-          <input
-            className="bg-bg-secondary border border-border rounded-lg px-3.5 py-2.5 text-text-primary text-sm flex-1 outline-none focus:border-accent transition-colors duration-150 placeholder:text-text-muted [&::-webkit-search-cancel-button]:hidden [&::-webkit-clear-button]:hidden [&::-ms-clear]:hidden"
-            style={{ WebkitAppearance: 'none' }}
-            placeholder="Notes (optional)"
-            value={form.notes}
-            onChange={e => setForm({ ...form, notes: e.target.value })}
-          />
-          <button
-            type="submit"
-            className="bg-accent text-black border-none px-5 py-2.5 rounded-lg text-sm font-medium cursor-pointer self-end disabled:opacity-50 disabled:cursor-not-allowed"
-            disabled={adding}
-          >
-            {adding ? 'Adding...' : 'Add to Schedule'}
-          </button>
-        </form>
-      )}
-
-      {loading ? (
-        <div className="text-text-muted py-12 text-center">Loading schedule...</div>
-      ) : content ? (
-        <div className="bg-bg-card border border-border rounded-xl p-6 leading-[1.7] text-text-primary text-sm [&_h1]:my-4 [&_h1]:mb-2 [&_h1]:text-xl [&_h1]:text-text-primary [&_h2]:my-4 [&_h2]:mb-2 [&_h2]:text-[17px] [&_h2]:text-text-primary [&_h3]:my-4 [&_h3]:mb-2 [&_h3]:text-[15px] [&_h3]:text-text-primary [&_p]:my-2 [&_table]:w-full [&_table]:border-collapse [&_table]:my-3 [&_th]:text-left [&_th]:px-3 [&_th]:py-2 [&_th]:border-b [&_th]:border-border [&_th]:text-xs [&_th]:text-text-muted [&_th]:font-semibold [&_th]:uppercase [&_th]:tracking-wide [&_td]:text-left [&_td]:px-3 [&_td]:py-2 [&_td]:border-b [&_td]:border-border [&_td]:text-[13px] [&_td]:text-text-primary [&_strong]:text-accent [&_hr]:border-none [&_hr]:border-t [&_hr]:border-border [&_hr]:my-4">
-          <Markdown remarkPlugins={[remarkGfm]}>{content}</Markdown>
-        </div>
-      ) : (
-        <div className="text-center py-16 text-text-secondary">
-          <p className="my-2">No schedule found.</p>
-          <p className="text-sm text-text-muted my-2">
-            Use <code className="bg-bg-card px-1.5 py-0.5 rounded text-[13px]">oracle_schedule_add</code> or click "+ Add Event".
-          </p>
-        </div>
-      )}
-    </SidebarLayout>
+    <div className="min-h-[60vh] flex items-center justify-center text-text-muted text-sm">
+      Redirecting to {SCHEDULE_ORIGIN} …
+    </div>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,50 @@
         "vite": "^7.2.4",
       },
     },
+    "apps/feed": {
+      "name": "feed-oracle-studio",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ui-oracle/shared-ui": "workspace:*",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "react-router-dom": "^7.11.0",
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.2.1",
+        "@types/bun": "^1.3.12",
+        "@types/node": "^24.10.1",
+        "@types/react": "^19.2.5",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.1.1",
+        "tailwindcss": "^4.2.1",
+        "typescript": "~5.9.3",
+        "vite": "^7.2.4",
+      },
+    },
+    "apps/schedule": {
+      "name": "schedule-oracle-studio",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ui-oracle/shared-ui": "workspace:*",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "react-markdown": "^10.1.0",
+        "react-router-dom": "^7.11.0",
+        "remark-gfm": "^4.0.1",
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.2.1",
+        "@types/bun": "^1.3.12",
+        "@types/node": "^24.10.1",
+        "@types/react": "^19.2.5",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.1.1",
+        "tailwindcss": "^4.2.1",
+        "typescript": "~5.9.3",
+        "vite": "^7.2.4",
+      },
+    },
     "apps/studio": {
       "name": "oracle-studio",
       "version": "0.8.0",
@@ -697,6 +741,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "feed-oracle-studio": ["feed-oracle-studio@workspace:apps/feed"],
+
     "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
@@ -1078,6 +1124,8 @@
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "schedule-oracle-studio": ["schedule-oracle-studio@workspace:apps/schedule"],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -15,13 +15,17 @@
     "dev:studio": "bun --cwd apps/studio run dev",
     "dev:vector": "bun --cwd apps/vector run dev",
     "dev:canvas": "bun --cwd apps/canvas run dev",
+    "dev:schedule": "bun --cwd apps/schedule run dev",
     "build:studio": "bun --cwd apps/studio run build",
     "build:vector": "bun --cwd apps/vector run build",
     "build:canvas": "bun --cwd apps/canvas run build",
-    "build:all": "bun run build:studio && bun run build:vector && bun run build:canvas",
+    "build:schedule": "bun --cwd apps/schedule run build",
+    "build:all": "bun run build:studio && bun run build:vector && bun run build:canvas && bun run build:schedule",
     "preview:studio": "bun --cwd apps/studio run preview",
     "preview:vector": "bun --cwd apps/vector run preview",
-    "preview:canvas": "bun --cwd apps/canvas run preview"
+    "preview:canvas": "bun --cwd apps/canvas run preview",
+    "preview:schedule": "bun --cwd apps/schedule run preview",
+    "deploy:schedule": "bun --cwd apps/schedule run deploy"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- New `apps/schedule` bundle scaffolded from `apps/canvas` template → deployed to `schedule.buildwithoracle.com` (CF Worker + assets, custom domain live, HTTP 200)
- `apps/studio` Schedule route becomes a thin cross-origin redirect (preserves `?host=` param when jumping from studio to schedule)
- Root scripts: `dev:schedule`, `build:schedule`, `deploy:schedule`, `preview:schedule`

## Test plan
- [x] `bun run build` (apps/schedule) green
- [x] `bunx wrangler deploy` — custom domain attached
- [x] `curl schedule.buildwithoracle.com` → 200
- [x] `bun run build` (apps/studio) green (redirect stub compiles)
- [ ] Manual: `studio.buildwithoracle.com/schedule` → lands on `schedule.buildwithoracle.com/?host=…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)