### PR TITLE
feat(canvas): populate plugins (map default)

### DIFF
--- a/apps/canvas/package.json
+++ b/apps/canvas/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@types/three": "^0.184.0",
     "@ui-oracle/shared-ui": "workspace:*",
+    "knowledge-map-3d": "github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.11.0",

--- a/apps/canvas/src/api/oracle.ts
+++ b/apps/canvas/src/api/oracle.ts
@@ -5,9 +5,69 @@ export { apiUrl, hostLabel, activeHost, isDefault, isRemote } from './host';
 export const API_BASE = apiUrl('/api');
 
 const ONE_HOUR = 60 * 60 * 1000;
+const ONE_DAY = 24 * ONE_HOUR;
+const TEN_MIN = 10 * 60 * 1000;
+
+export interface Document {
+  id: string;
+  type: string;
+  content?: string;
+  source_file: string;
+  concepts: string[];
+  project?: string;
+  source?: string;
+  score?: number;
+  distance?: number;
+  model?: string;
+  created_at?: string;
+}
+
+export interface MapDocument {
+  id: string;
+  type: string;
+  source_file: string;
+  concepts: string[];
+  chunk_ids?: string[];
+  project: string | null;
+  x: number;
+  y: number;
+  z?: number;
+  created_at: string | null;
+}
+
+export interface OracleProject {
+  project: string;
+  docs: number;
+  types: number;
+  last_indexed: number;
+}
+
+export interface OracleIdentity {
+  oracle_name: string;
+  source: string;
+  last_seen: number;
+  actions: number;
+}
 
 export interface Stats {
+  total?: number;
+  by_type?: Record<string, number>;
+  by_type_files?: Record<string, number>;
+  last_indexed?: string;
+  vectors?: Array<{
+    key: string;
+    model: string;
+    collection: string;
+    count: number;
+    enabled: boolean;
+  }>;
   [key: string]: unknown;
+}
+
+export interface SearchResult {
+  results: Document[];
+  total: number;
+  query: string;
 }
 
 export async function getStats(): Promise<Stats> {
@@ -18,7 +78,6 @@ export async function getStats(): Promise<Stats> {
   }, { tag: 'stats' });
 }
 
-/** Ping the backend — used by the header status chip. */
 export async function ping(): Promise<boolean> {
   try {
     const res = await fetch(`${API_BASE}/stats`, { signal: AbortSignal.timeout(2000) });
@@ -26,4 +85,46 @@ export async function ping(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+export async function getMap(): Promise<{ documents: MapDocument[]; total: number }> {
+  const res = await fetch(`${API_BASE}/map`);
+  return res.json();
+}
+
+export async function getMap3d(model?: string): Promise<{ documents: MapDocument[]; total: number; pca_info?: unknown }> {
+  const params = model ? `?model=${encodeURIComponent(model)}` : '';
+  const key = `map3d:${model ?? 'default'}`;
+  return cached(key, ONE_DAY, async () => {
+    const res = await fetch(`${API_BASE}/map3d${params}`);
+    return res.json();
+  }, { tag: 'map3d', store: 'idb' });
+}
+
+export async function getOracles(): Promise<{
+  identities: OracleIdentity[];
+  projects: OracleProject[];
+  total_projects: number;
+  total_identities: number;
+}> {
+  return cached('oracles', ONE_DAY, async () => {
+    const res = await fetch(`${API_BASE}/oracles`);
+    return res.json();
+  }, { tag: 'oracles' });
+}
+
+export async function search(
+  query: string,
+  type: string = 'all',
+  limit: number = 20,
+  mode: 'hybrid' | 'fts' | 'vector' = 'hybrid',
+  model?: string,
+): Promise<SearchResult> {
+  const params = new URLSearchParams({ q: query, type, limit: String(limit), mode });
+  if (model) params.set('model', model);
+  const qs = params.toString();
+  return cached(`search:${qs}`, TEN_MIN, async () => {
+    const res = await fetch(`${API_BASE}/search?${qs}`);
+    return res.json();
+  }, { tag: 'search' });
 }

--- a/apps/canvas/src/components/planets/EngineList.tsx
+++ b/apps/canvas/src/components/planets/EngineList.tsx
@@ -1,0 +1,64 @@
+import type { Stats } from '../../api/oracle';
+
+type Engine = NonNullable<Stats['vectors']>[number];
+
+interface Props {
+  engines: Engine[];
+  model: string | undefined;
+  onSetModel: (m: string | undefined) => void;
+}
+
+export function EngineList({ engines, model, onSetModel }: Props) {
+  if (engines.length === 0) return null;
+  const activeKey = model ?? 'bge-m3';
+
+  return (
+    <>
+      <div className="h-px bg-border my-1" />
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-mono uppercase tracking-wide text-text-muted">
+          Embedding Engines
+        </span>
+        <span className="text-[9px] font-mono text-text-muted">LanceDB</span>
+      </div>
+      {engines.map((v) => {
+        const active = activeKey === v.key;
+        return (
+          <button
+            key={v.key}
+            onClick={() => v.enabled && onSetModel(v.key)}
+            disabled={!v.enabled}
+            className={`flex flex-col gap-0.5 p-2 rounded-lg border text-left transition-all duration-150 ${
+              active
+                ? 'border-accent/40 bg-accent/5'
+                : v.enabled
+                ? 'border-border bg-white/[0.02] hover:border-border-hover cursor-pointer'
+                : 'border-border-subtle opacity-50 cursor-not-allowed'
+            }`}
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-semibold text-text-primary">{v.key}</span>
+              <span
+                className={`text-[9px] font-mono font-semibold uppercase px-1.5 py-0.5 rounded ${
+                  active
+                    ? 'bg-accent/20 text-accent'
+                    : v.enabled
+                    ? 'bg-success/20 text-success'
+                    : 'bg-red-500/20 text-red-400'
+                }`}
+              >
+                {active ? 'Active' : v.enabled ? 'Switch' : 'Offline'}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-text-muted font-mono">{v.model}</span>
+              <span className="text-[9px] text-text-muted tabular-nums">
+                {v.count.toLocaleString()}
+              </span>
+            </div>
+          </button>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/canvas/src/components/planets/NebulaLegend.tsx
+++ b/apps/canvas/src/components/planets/NebulaLegend.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'planets.legend.dismissed';
+const OVERLAY_BG = 'rgba(10, 10, 20, 0.75)';
+
+export function NebulaLegend() {
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    try {
+      setDismissed(localStorage.getItem(STORAGE_KEY) === '1');
+    } catch {
+      setDismissed(false);
+    }
+  }, []);
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, '1');
+    } catch {}
+    setDismissed(true);
+  };
+
+  if (dismissed) return null;
+
+  return (
+    <div
+      className="absolute bottom-4 right-4 max-w-[260px] rounded-[10px] px-3.5 py-3 text-[11px] text-text-secondary backdrop-blur-xl border border-white/[0.08] z-10 leading-relaxed"
+      style={{ background: OVERLAY_BG }}
+    >
+      <div className="flex items-start justify-between gap-3 mb-1">
+        <span className="text-xs font-semibold text-text-primary">Nebula Legend</span>
+        <button
+          onClick={dismiss}
+          className="text-text-muted hover:text-accent cursor-pointer text-xs leading-none"
+          aria-label="Dismiss"
+        >
+          ×
+        </button>
+      </div>
+      <p>
+        Colored clouds connect projects that share concepts. Brighter = stronger overlap. Click a planet to open its document.
+      </p>
+    </div>
+  );
+}

--- a/apps/canvas/src/components/planets/PlanetsCanvas.tsx
+++ b/apps/canvas/src/components/planets/PlanetsCanvas.tsx
@@ -1,0 +1,36 @@
+import { KnowledgeMap } from 'knowledge-map-3d';
+import type { MapDocument, ClusterMeta, NebulaMeta } from 'knowledge-map-3d';
+import { TYPE_COLORS } from '../../lib/type-colors';
+
+interface Props {
+  documents: MapDocument[];
+  clusters: ClusterMeta[];
+  nebulae: NebulaMeta[];
+  highlightIds: Set<string>;
+  onDocumentClick: (doc: MapDocument) => void;
+  onClusterClick?: (cluster: ClusterMeta) => void;
+}
+
+export function PlanetsCanvas({
+  documents,
+  clusters,
+  nebulae,
+  highlightIds,
+  onDocumentClick,
+  onClusterClick,
+}: Props) {
+  return (
+    <KnowledgeMap
+      documents={documents}
+      clusters={clusters}
+      nebulae={nebulae}
+      highlightIds={highlightIds}
+      onDocumentClick={onDocumentClick}
+      onClusterClick={onClusterClick}
+      typeColors={TYPE_COLORS}
+      embedded
+      heightMode="auto"
+      className="w-full h-full"
+    />
+  );
+}

--- a/apps/canvas/src/components/planets/PlanetsEmpty.tsx
+++ b/apps/canvas/src/components/planets/PlanetsEmpty.tsx
@@ -1,0 +1,36 @@
+export function PlanetsLoading() {
+  return (
+    <div className="flex flex-col items-center justify-center h-[calc(100vh-64px)] gap-3 bg-black">
+      <div className="text-lg text-text-primary">Loading planets...</div>
+      <div className="text-[13px] text-text-muted">
+        Fetching embeddings and building the universe...
+      </div>
+    </div>
+  );
+}
+
+interface EmptyProps {
+  message?: string;
+}
+
+export function PlanetsEmpty({ message }: EmptyProps) {
+  const hasError = Boolean(message);
+  return (
+    <div className="flex flex-col items-center justify-center h-[calc(100vh-64px)] gap-3 bg-black text-center px-6">
+      <div className={`text-[22px] font-bold ${hasError ? 'text-[#ef4444]' : 'text-text-primary'}`}>
+        {hasError ? 'Failed to load planets' : 'No Planets Yet'}
+      </div>
+      <div className="text-sm text-text-muted leading-relaxed max-w-md">
+        {hasError ? (
+          message
+        ) : (
+          <>
+            The planets universe needs vector embeddings from LanceDB.
+            <br />
+            Run a vector index to populate the map.
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/canvas/src/components/planets/PlanetsHUD.tsx
+++ b/apps/canvas/src/components/planets/PlanetsHUD.tsx
@@ -1,0 +1,80 @@
+import { TYPE_COLORS } from '../../lib/type-colors';
+
+interface Props {
+  query: string;
+  onQueryChange: (q: string) => void;
+  onClear: () => void;
+  searching?: boolean;
+  matchCount: number;
+  visibleTypes: Set<string>;
+  onToggleType: (type: string) => void;
+}
+
+const OVERLAY_BG = 'rgba(10, 10, 20, 0.7)';
+
+export function PlanetsHUD({
+  query,
+  onQueryChange,
+  onClear,
+  searching = false,
+  matchCount,
+  visibleTypes,
+  onToggleType,
+}: Props) {
+  return (
+    <>
+      <form
+        onSubmit={(e) => e.preventDefault()}
+        className="absolute top-4 left-1/2 -translate-x-1/2 flex gap-2 z-10 items-center"
+      >
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          placeholder="Search to highlight planets..."
+          className="w-[320px] px-4 py-2.5 rounded-[10px] text-sm text-text-primary border border-white/[0.08] outline-none backdrop-blur-xl transition-colors duration-200 focus:border-accent placeholder:text-text-muted [&::-webkit-search-cancel-button]:hidden [&::-webkit-clear-button]:hidden [&::-ms-clear]:hidden"
+          style={{ background: OVERLAY_BG, WebkitAppearance: 'none' }}
+        />
+        {query && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="px-3.5 py-2 rounded-[10px] text-xs text-text-secondary cursor-pointer border border-white/[0.08] backdrop-blur-xl transition-all duration-200 hover:border-accent hover:text-accent"
+            style={{ background: OVERLAY_BG }}
+          >
+            Clear
+          </button>
+        )}
+        {searching && <span className="w-2 h-2 rounded-full bg-accent animate-pulse" />}
+        {query && matchCount > 0 && (
+          <span
+            className="text-[11px] font-mono text-text-muted px-2 py-1 rounded-md backdrop-blur-xl border border-white/[0.08]"
+            style={{ background: OVERLAY_BG }}
+          >
+            {matchCount} match{matchCount === 1 ? '' : 'es'}
+          </span>
+        )}
+      </form>
+
+      <div
+        className="absolute bottom-4 left-4 flex gap-1 rounded-[10px] px-2 py-1.5 text-[11px] text-text-secondary backdrop-blur-xl border border-white/[0.08] z-10"
+        style={{ background: OVERLAY_BG }}
+      >
+        {Object.entries(TYPE_COLORS).map(([type, color]) => {
+          const active = visibleTypes.has(type);
+          return (
+            <button
+              key={type}
+              onClick={() => onToggleType(type)}
+              className={`flex items-center gap-[5px] px-2 py-1 rounded-md cursor-pointer border-none transition-all duration-150 ${active ? 'opacity-100' : 'opacity-30'}`}
+              style={{ background: active ? `${color}15` : 'transparent' }}
+            >
+              <span className="w-[7px] h-[7px] rounded-full" style={{ background: color }} />
+              {type}
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/apps/canvas/src/components/planets/PlanetsSidebar.tsx
+++ b/apps/canvas/src/components/planets/PlanetsSidebar.tsx
@@ -1,0 +1,129 @@
+import type { ClusterMeta } from 'knowledge-map-3d';
+import type { Stats } from '../../api/oracle';
+import { TYPE_COLORS } from '../../lib/type-colors';
+import { EngineList } from './EngineList';
+
+interface Props {
+  stats: Stats | null;
+  clusters: ClusterMeta[];
+  totalDocs: number;
+  typeCounts: Record<string, number>;
+  matchCount: number;
+  selectedProject: string | null;
+  onSelectProject: (project: string | null) => void;
+  model: string | undefined;
+  onSetModel: (m: string | undefined) => void;
+}
+
+export function PlanetsSidebar({
+  stats,
+  clusters,
+  totalDocs,
+  typeCounts,
+  matchCount,
+  selectedProject,
+  onSelectProject,
+  model,
+  onSetModel,
+}: Props) {
+  const sorted = [...clusters].sort((a, b) => b.docCount - a.docCount);
+
+  return (
+    <div className="w-[260px] bg-bg-card border-l border-border p-6 flex flex-col overflow-hidden">
+      <h2 className="text-xl font-bold text-text-primary mb-1">Planets</h2>
+      <span className="text-[11px] font-mono text-text-muted mb-4 block">
+        {clusters.length} cluster{clusters.length === 1 ? '' : 's'} active
+      </span>
+
+      <div className="flex flex-col gap-4 flex-1 min-h-0 overflow-y-auto">
+        {stats?.total != null && <Stat value={stats.total as number} label="Total Indexed" />}
+        <Stat value={totalDocs} label="Documents Mapped" />
+
+        {Object.entries(typeCounts).map(([type, count]) => (
+          <Stat key={type} value={count} label={`${type}s`} color={TYPE_COLORS[type]} />
+        ))}
+
+        <EngineList engines={stats?.vectors ?? []} model={model} onSetModel={onSetModel} />
+
+        {sorted.length > 0 && (
+          <ProjectList
+            clusters={sorted}
+            selectedProject={selectedProject}
+            onSelectProject={onSelectProject}
+          />
+        )}
+
+        {matchCount > 0 && (
+          <>
+            <div className="h-px bg-border my-1" />
+            <Stat value={matchCount} label="Search Matches" color="#4ade80" />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Stat({ value, label, color }: { value: number; label: string; color?: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xl font-bold tabular-nums" style={color ? { color } : undefined}>
+        {value.toLocaleString()}
+      </span>
+      <span className="text-xs text-text-muted capitalize">{label}</span>
+    </div>
+  );
+}
+
+function ProjectList({
+  clusters,
+  selectedProject,
+  onSelectProject,
+}: {
+  clusters: ClusterMeta[];
+  selectedProject: string | null;
+  onSelectProject: (p: string | null) => void;
+}) {
+  return (
+    <>
+      <div className="h-px bg-border my-1" />
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-mono uppercase tracking-wide text-text-muted">Projects</span>
+        {selectedProject && (
+          <button
+            onClick={() => onSelectProject(null)}
+            className="text-[9px] font-mono text-accent cursor-pointer hover:underline"
+          >
+            Clear filter
+          </button>
+        )}
+      </div>
+      <div className="flex flex-col gap-0.5">
+        {clusters.map((c) => {
+          const isSel = selectedProject === c.id;
+          return (
+            <button
+              key={c.id}
+              onClick={() => onSelectProject(isSel ? null : c.id)}
+              className={`flex items-center justify-between py-1 px-1.5 gap-2 rounded-md cursor-pointer text-left transition-all duration-150 border-none ${
+                isSel ? 'bg-accent/15' : 'bg-transparent hover:bg-white/[0.04]'
+              }`}
+            >
+              <span
+                className={`text-xs truncate ${isSel ? 'text-accent font-semibold' : 'text-text-primary'}`}
+                title={c.id}
+              >
+                {c.label}
+              </span>
+              <span
+                className={`text-[9px] tabular-nums ${isSel ? 'text-accent' : 'text-text-muted'}`}
+              >
+                {c.docCount}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/apps/canvas/src/hooks/usePlanetsData.ts
+++ b/apps/canvas/src/hooks/usePlanetsData.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ClusterMeta, MapDocument, NebulaMeta } from 'knowledge-map-3d';
+import { getMap, getMap3d, getOracles, getStats } from '../api/oracle';
+import type { MapDocument as ApiMapDocument, Stats } from '../api/oracle';
+import { buildPlanetsGraph } from '../lib/planets';
+
+export interface UsePlanetsData {
+  documents: MapDocument[];
+  clusters: ClusterMeta[];
+  nebulae: NebulaMeta[];
+  stats: Stats | null;
+  loading: boolean;
+  error: string | null;
+  reload: () => void;
+  model: string | undefined;
+  setModel: (m: string | undefined) => void;
+}
+
+const EMPTY_ORACLES = {
+  projects: [],
+  identities: [],
+  total_projects: 0,
+  total_identities: 0,
+};
+
+export function usePlanetsData(initialModel?: string): UsePlanetsData {
+  const [documents, setDocuments] = useState<MapDocument[]>([]);
+  const [clusters, setClusters] = useState<ClusterMeta[]>([]);
+  const [nebulae, setNebulae] = useState<NebulaMeta[]>([]);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [model, setModel] = useState<string | undefined>(initialModel);
+  const [tick, setTick] = useState(0);
+  const reqId = useRef(0);
+
+  const reload = useCallback(() => setTick((t) => t + 1), []);
+
+  useEffect(() => {
+    const id = ++reqId.current;
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        let apiDocs: ApiMapDocument[];
+        try {
+          const map = await getMap3d(model);
+          apiDocs = map.documents ?? [];
+        } catch {
+          const map2d = await getMap();
+          apiDocs = (map2d.documents ?? []).map((d) => ({ ...d, z: 0 }));
+        }
+
+        const [oracles, statsResp] = await Promise.all([
+          getOracles().catch(() => EMPTY_ORACLES),
+          getStats().catch<Stats | null>(() => null),
+        ]);
+
+        if (id !== reqId.current) return;
+
+        const graph = buildPlanetsGraph(
+          apiDocs,
+          oracles.projects,
+          statsResp ?? undefined,
+        );
+        setDocuments(graph.documents);
+        setClusters(graph.clusters);
+        setNebulae(graph.nebulae);
+        setStats(statsResp);
+        setLoading(false);
+      } catch (e) {
+        if (id !== reqId.current) return;
+        setError(e instanceof Error ? e.message : String(e));
+        setLoading(false);
+      }
+    })();
+  }, [model, tick]);
+
+  return { documents, clusters, nebulae, stats, loading, error, reload, model, setModel };
+}

--- a/apps/canvas/src/hooks/usePlanetsSearch.ts
+++ b/apps/canvas/src/hooks/usePlanetsSearch.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { search } from '../api/oracle';
+import type { Document } from '../api/oracle';
+
+export interface UsePlanetsSearch {
+  query: string;
+  setQuery: (q: string) => void;
+  matchIds: Set<string>;
+  matching: Document[];
+  error: string | null;
+  clear: () => void;
+}
+
+export function usePlanetsSearch(debounceMs: number = 300): UsePlanetsSearch {
+  const [query, setQueryState] = useState('');
+  const [matching, setMatching] = useState<Document[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const q = query.trim();
+    if (!q) {
+      setMatching([]);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        const res = await search(q, 'all', 50, 'hybrid');
+        if (cancelled) return;
+        setMatching(res.results ?? []);
+        setError(null);
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+        setMatching([]);
+      }
+    }, debounceMs);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query, debounceMs]);
+
+  const matchIds = useMemo(
+    () => new Set(matching.map((d) => d.id)),
+    [matching],
+  );
+
+  const setQuery = useCallback((q: string) => setQueryState(q), []);
+  const clear = useCallback(() => setQueryState(''), []);
+
+  return { query, setQuery, matchIds, matching, error, clear };
+}

--- a/apps/canvas/src/lib/planets/adapter.ts
+++ b/apps/canvas/src/lib/planets/adapter.ts
@@ -1,0 +1,123 @@
+import type {
+  MapDocument as KMDocument,
+  ClusterMeta,
+  NebulaMeta,
+} from 'knowledge-map-3d';
+import type {
+  MapDocument as ApiMapDocument,
+  OracleProject,
+  Stats,
+} from '../../api/oracle';
+import { placeProjectsOnSphere, type ClusterPosition } from './layout';
+import { computeOrbit } from './orbits';
+import { buildNebulae } from './nebulae';
+
+export interface PlanetsGraph {
+  documents: KMDocument[];
+  clusters: ClusterMeta[];
+  nebulae: NebulaMeta[];
+}
+
+const UNKNOWN_CLUSTER = '__unknown__';
+
+export function buildPlanetsGraph(
+  apiDocs: ApiMapDocument[],
+  projects: OracleProject[],
+  _stats?: Stats,
+  now: number = Date.now(),
+): PlanetsGraph {
+  const centers = placeProjectsOnSphere(projects);
+  const docsByProject = groupDocsByProject(apiDocs);
+
+  if (docsByProject.has(UNKNOWN_CLUSTER) && !centers.has(UNKNOWN_CLUSTER)) {
+    centers.set(UNKNOWN_CLUSTER, { cx: 0, cy: 0, cz: 0, radius: 6 });
+  }
+
+  const documents: KMDocument[] = [];
+  const clusters: ClusterMeta[] = [];
+  const projectConcepts = new Map<string, Set<string>>();
+
+  for (const [projectId, center] of centers.entries()) {
+    const docs = docsByProject.get(projectId) ?? [];
+    const concepts = new Set<string>();
+
+    docs.forEach((d, i) => {
+      const orbit = computeOrbit(d, center, i, now);
+      const createdAtMs = parseUnixMs(d.created_at);
+      for (const c of d.concepts ?? []) concepts.add(c);
+      documents.push({
+        id: d.id,
+        type: d.type,
+        sourceFile: d.source_file,
+        concepts: d.concepts ?? [],
+        chunkIds: d.chunk_ids,
+        project: d.project ?? null,
+        x: orbit.x,
+        y: orbit.y,
+        z: orbit.z,
+        clusterId: projectId,
+        orbitRadius: orbit.orbitRadius,
+        orbitSpeed: orbit.orbitSpeed,
+        orbitPhase: orbit.orbitPhase,
+        orbitTilt: orbit.orbitTilt,
+        parentId: null,
+        moonCount: 0,
+        createdAt: createdAtMs,
+        contentLength: estimateContentLength(d),
+      });
+    });
+
+    projectConcepts.set(projectId, concepts);
+
+    clusters.push({
+      id: projectId,
+      label: clusterLabel(projectId),
+      docCount: docs.length,
+      cx: center.cx,
+      cy: center.cy,
+      cz: center.cz,
+      radius: center.radius,
+      concepts: Array.from(concepts).slice(0, 8),
+      starDocId: docs[0]?.id ?? null,
+    });
+  }
+
+  const centerLite = new Map<string, { cx: number; cy: number; cz: number }>();
+  for (const [k, v] of centers.entries()) {
+    centerLite.set(k, { cx: v.cx, cy: v.cy, cz: v.cz });
+  }
+  const nebulae = buildNebulae(projectConcepts, centerLite);
+
+  return { documents, clusters, nebulae };
+}
+
+function groupDocsByProject(apiDocs: ApiMapDocument[]): Map<string, ApiMapDocument[]> {
+  const out = new Map<string, ApiMapDocument[]>();
+  for (const d of apiDocs) {
+    const key = d.project ?? UNKNOWN_CLUSTER;
+    const arr = out.get(key) ?? [];
+    arr.push(d);
+    out.set(key, arr);
+  }
+  return out;
+}
+
+function parseUnixMs(s: string | null | undefined): number | null {
+  if (!s) return null;
+  const t = Date.parse(s);
+  return Number.isFinite(t) ? t : null;
+}
+
+function estimateContentLength(d: ApiMapDocument): number {
+  const conceptsLen = (d.concepts ?? []).join(' ').length;
+  const pathLen = (d.source_file ?? '').length;
+  return 500 + conceptsLen * 20 + pathLen * 4;
+}
+
+function clusterLabel(project: string): string {
+  if (project === UNKNOWN_CLUSTER) return 'Unsorted';
+  const parts = project.split('/');
+  return parts[parts.length - 1] || project;
+}
+
+export type { ClusterPosition };

--- a/apps/canvas/src/lib/planets/colors.ts
+++ b/apps/canvas/src/lib/planets/colors.ts
@@ -1,0 +1,67 @@
+export const TYPE_COLORS: Record<string, string> = {
+  principle: '#60a5fa',
+  learning: '#a78bfa',
+  retro: '#fbbf24',
+  unknown: '#888888',
+};
+
+const FALLBACK = '#888888';
+
+export function clusterColorFromTypes(counts: Record<string, number>): string {
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  let total = 0;
+  for (const [type, n] of Object.entries(counts)) {
+    if (!n || n <= 0) continue;
+    const [cr, cg, cb] = hexToRgb(TYPE_COLORS[type] ?? FALLBACK);
+    r += cr * n;
+    g += cg * n;
+    b += cb * n;
+    total += n;
+  }
+  if (total === 0) return FALLBACK;
+  return rgbToHex(Math.round(r / total), Math.round(g / total), Math.round(b / total));
+}
+
+export function planetColor(type: string, ageDays: number): string {
+  const base = TYPE_COLORS[type] ?? FALLBACK;
+  let shift = 0;
+  if (ageDays < 7) shift = 0.2;
+  else if (ageDays > 30) shift = -0.2;
+  return shiftLightness(base, shift);
+}
+
+export function ageInDays(createdAt: number | null | undefined, now: number = Date.now()): number {
+  if (createdAt == null) return Infinity;
+  return Math.max(0, (now - createdAt) / 86_400_000);
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const clean = hex.replace('#', '');
+  const full = clean.length === 3 ? clean.split('').map((c) => c + c).join('') : clean;
+  const n = parseInt(full, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return '#' + [r, g, b].map((v) => clamp(v, 0, 255).toString(16).padStart(2, '0')).join('');
+}
+
+function shiftLightness(hex: string, delta: number): string {
+  const [r, g, b] = hexToRgb(hex);
+  if (delta === 0) return hex;
+  if (delta > 0) {
+    return rgbToHex(
+      Math.round(r + (255 - r) * delta),
+      Math.round(g + (255 - g) * delta),
+      Math.round(b + (255 - b) * delta),
+    );
+  }
+  const f = 1 + delta;
+  return rgbToHex(Math.round(r * f), Math.round(g * f), Math.round(b * f));
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, n));
+}

--- a/apps/canvas/src/lib/planets/index.ts
+++ b/apps/canvas/src/lib/planets/index.ts
@@ -1,0 +1,5 @@
+export * from './colors';
+export * from './layout';
+export * from './orbits';
+export * from './nebulae';
+export * from './adapter';

--- a/apps/canvas/src/lib/planets/layout.ts
+++ b/apps/canvas/src/lib/planets/layout.ts
@@ -1,0 +1,58 @@
+import type { OracleProject } from '../../api/oracle';
+
+export interface ClusterPosition {
+  cx: number;
+  cy: number;
+  cz: number;
+  radius: number;
+}
+
+export interface LayoutOptions {
+  radius?: number;
+  minClusterRadius?: number;
+  maxClusterRadius?: number;
+}
+
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
+
+export function placeProjectsOnSphere(
+  projects: OracleProject[],
+  options: LayoutOptions = {},
+): Map<string, ClusterPosition> {
+  const out = new Map<string, ClusterPosition>();
+  const N = projects.length;
+  if (N === 0) return out;
+
+  const totalDocs = projects.reduce((s, p) => s + (p.docs ?? 0), 0);
+  const sphereRadius = options.radius ?? Math.max(12, 6 * Math.log2(Math.max(2, totalDocs)));
+  const minR = options.minClusterRadius ?? 4;
+  const maxR = options.maxClusterRadius ?? 14;
+
+  if (N === 1) {
+    const p = projects[0];
+    out.set(p.project, { cx: 0, cy: 0, cz: 0, radius: clusterRadiusFor(p.docs ?? 0, minR, maxR) });
+    return out;
+  }
+
+  for (let i = 0; i < N; i++) {
+    const y = 1 - (2 * i) / (N - 1);
+    const rRing = Math.sqrt(Math.max(0, 1 - y * y));
+    const theta = GOLDEN_ANGLE * i;
+    const cx = Math.cos(theta) * rRing * sphereRadius;
+    const cy = y * sphereRadius;
+    const cz = Math.sin(theta) * rRing * sphereRadius;
+    const p = projects[i];
+    out.set(p.project, {
+      cx,
+      cy,
+      cz,
+      radius: clusterRadiusFor(p.docs ?? 0, minR, maxR),
+    });
+  }
+  return out;
+}
+
+export function clusterRadiusFor(docCount: number, minR = 4, maxR = 14): number {
+  const scaled = Math.log2(Math.max(2, docCount + 1)) * 2;
+  return Math.min(maxR, Math.max(minR, scaled));
+}

--- a/apps/canvas/src/lib/planets/nebulae.ts
+++ b/apps/canvas/src/lib/planets/nebulae.ts
@@ -1,0 +1,80 @@
+import type { NebulaMeta } from 'knowledge-map-3d';
+
+export interface ClusterCenterLite {
+  cx: number;
+  cy: number;
+  cz: number;
+}
+
+export interface NebulaOptions {
+  minShared?: number;
+}
+
+export function buildNebulae(
+  projectConcepts: Map<string, Set<string>>,
+  clusterCenters: Map<string, ClusterCenterLite>,
+  options: NebulaOptions = {},
+): NebulaMeta[] {
+  const minShared = options.minShared ?? 3;
+  const keys = Array.from(projectConcepts.keys())
+    .filter((k) => clusterCenters.has(k))
+    .sort();
+
+  const out: NebulaMeta[] = [];
+  for (let i = 0; i < keys.length; i++) {
+    for (let j = i + 1; j < keys.length; j++) {
+      const a = keys[i];
+      const b = keys[j];
+      const A = projectConcepts.get(a);
+      const B = projectConcepts.get(b);
+      if (!A || !B) continue;
+      const { shared, jaccard } = overlap(A, B);
+      if (shared < minShared) continue;
+      const ca = clusterCenters.get(a);
+      const cb = clusterCenters.get(b);
+      if (!ca || !cb) continue;
+      out.push({
+        id: `neb-${a}-${b}`,
+        clusterA: a,
+        clusterB: b,
+        cx: (ca.cx + cb.cx) / 2,
+        cy: (ca.cy + cb.cy) / 2,
+        cz: (ca.cz + cb.cz) / 2,
+        strength: jaccard,
+        color: conceptHueColor(sharedConcepts(A, B)),
+      });
+    }
+  }
+  return out;
+}
+
+export function overlap(a: Set<string>, b: Set<string>): { shared: number; jaccard: number } {
+  let shared = 0;
+  for (const v of a) if (b.has(v)) shared++;
+  const union = a.size + b.size - shared;
+  return { shared, jaccard: union === 0 ? 0 : shared / union };
+}
+
+function sharedConcepts(a: Set<string>, b: Set<string>): string[] {
+  const out: string[] = [];
+  for (const v of a) if (b.has(v)) out.push(v);
+  return out.sort();
+}
+
+function conceptHueColor(concepts: string[]): string {
+  let h = 0;
+  for (const c of concepts) {
+    for (let i = 0; i < c.length; i++) h = (h + c.charCodeAt(i)) % 360;
+  }
+  return hslToHex(h, 70, 60);
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const sN = s / 100;
+  const lN = l / 100;
+  const k = (n: number) => (n + h / 30) % 12;
+  const a = sN * Math.min(lN, 1 - lN);
+  const f = (n: number) => lN - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+  const toHex = (v: number) => Math.round(v * 255).toString(16).padStart(2, '0');
+  return `#${toHex(f(0))}${toHex(f(8))}${toHex(f(4))}`;
+}

--- a/apps/canvas/src/lib/planets/orbits.ts
+++ b/apps/canvas/src/lib/planets/orbits.ts
@@ -1,0 +1,66 @@
+import type { MapDocument as ApiMapDocument } from '../../api/oracle';
+
+export interface OrbitResult {
+  orbitRadius: number;
+  orbitSpeed: number;
+  orbitPhase: number;
+  orbitTilt: number;
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface ClusterCenter {
+  cx: number;
+  cy: number;
+  cz: number;
+  radius?: number;
+}
+
+export function computeOrbit(
+  doc: ApiMapDocument,
+  center: ClusterCenter,
+  docIndex: number,
+  now: number = Date.now(),
+): OrbitResult {
+  const dx = doc.x ?? 0;
+  const dy = doc.y ?? 0;
+  const dz = doc.z ?? 0;
+
+  const rawR = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
+  const clusterR = center.radius ?? 8;
+  const orbitRadius = clusterR * 0.3 + (rawR % clusterR);
+
+  const orbitPhase = Math.atan2(dy, dx);
+  const orbitTilt = hashTilt(doc.id ?? String(docIndex));
+  const orbitSpeed = speedFromCreatedAt(doc.created_at, now);
+
+  const x = center.cx + Math.cos(orbitPhase) * orbitRadius;
+  const y = center.cy + Math.sin(orbitPhase) * orbitRadius * Math.cos(orbitTilt);
+  const z = center.cz + Math.sin(orbitPhase) * orbitRadius * Math.sin(orbitTilt);
+
+  return { orbitRadius, orbitSpeed, orbitPhase, orbitTilt, x, y, z };
+}
+
+export function speedFromCreatedAt(
+  createdAt: string | null | undefined,
+  now: number = Date.now(),
+): number {
+  if (!createdAt) return 0.001;
+  const t = Date.parse(createdAt);
+  if (!Number.isFinite(t)) return 0.001;
+  const ageDays = (now - t) / 86_400_000;
+  if (ageDays < 7) return 0.003;
+  if (ageDays < 30) return 0.002;
+  return 0.001;
+}
+
+export function hashTilt(key: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < key.length; i++) {
+    h ^= key.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  const normalized = (h >>> 0) / 0xffffffff;
+  return normalized * 0.3;
+}

--- a/apps/canvas/src/lib/plugins/registry.ts
+++ b/apps/canvas/src/lib/plugins/registry.ts
@@ -1,5 +1,14 @@
 import type * as THREE from 'three';
 import type { FC } from 'react';
+import { mount as cubeMount } from '../../plugins/three/cube';
+import { mount as waveMount } from '../../plugins/three/wave';
+import { mount as torusMount } from '../../plugins/three/torus';
+import { mount as galaxyMount } from '../../plugins/three/galaxy';
+import { mount as solarMount } from '../../plugins/three/solar';
+import { mount as graph3dMount } from '../../plugins/three/graph3d';
+import { mount as map3dMount } from '../../plugins/three/map3d';
+import { MapPlugin } from '../../plugins/react/MapPlugin';
+import { PlanetsPlugin } from '../../plugins/react/PlanetsPlugin';
 
 export type SceneCtx = {
   scene: THREE.Scene;
@@ -14,7 +23,19 @@ export type CanvasPlugin =
   | { id: string; label: string; kind: 'three'; mount: SceneMount }
   | { id: string; label: string; kind: 'react'; renderer: FC };
 
-export const plugins: CanvasPlugin[] = [];
+export const plugins: CanvasPlugin[] = [
+  { id: 'map', label: 'Map', kind: 'react', renderer: MapPlugin },
+  { id: 'planets', label: 'Planets', kind: 'react', renderer: PlanetsPlugin },
+  { id: 'wave', label: 'Wave', kind: 'three', mount: waveMount },
+  { id: 'cube', label: 'Cube', kind: 'three', mount: cubeMount },
+  { id: 'torus', label: 'Torus', kind: 'three', mount: torusMount },
+  { id: 'galaxy', label: 'Galaxy', kind: 'three', mount: galaxyMount },
+  { id: 'solar', label: 'Solar', kind: 'three', mount: solarMount },
+  { id: 'graph3d', label: 'Graph 3D', kind: 'three', mount: graph3dMount },
+  { id: 'map3d', label: 'Map 3D', kind: 'three', mount: map3dMount },
+];
+
+export const DEFAULT_PLUGIN_ID = 'map';
 
 export function findPlugin(id: string): CanvasPlugin | undefined {
   return plugins.find((p) => p.id === id);

--- a/apps/canvas/src/lib/type-colors.ts
+++ b/apps/canvas/src/lib/type-colors.ts
@@ -1,0 +1,13 @@
+export const TYPE_COLORS: Record<string, string> = {
+  learning: '#60a5fa',
+  principle: '#c084fc',
+  retro: '#4ade80',
+  trace: '#38bdf8',
+  thread: '#a78bfa',
+  resonance: '#fb7185',
+  handoff: '#22d3ee',
+};
+
+export function getTypeColor(type: string): string {
+  return TYPE_COLORS[type] || '#888';
+}

--- a/apps/canvas/src/pages/CanvasHost.tsx
+++ b/apps/canvas/src/pages/CanvasHost.tsx
@@ -1,54 +1,124 @@
-import { useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
-import { PageShell } from '@ui-oracle/shared-ui';
-import { findPlugin, listPlugins } from '../lib/plugins/registry';
+import { useEffect, useMemo, useRef } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import * as THREE from 'three';
+import {
+  DEFAULT_PLUGIN_ID,
+  findPlugin,
+  listPlugins,
+  type CanvasPlugin,
+  type SceneMount,
+} from '../lib/plugins/registry';
 
 export default function CanvasHost() {
   const location = useLocation();
   const pluginId = useMemo(() => {
     const params = new URLSearchParams(location.search);
-    return params.get('plugin');
+    return params.get('plugin') ?? DEFAULT_PLUGIN_ID;
   }, [location.search]);
 
-  const plugin = pluginId ? findPlugin(pluginId) : undefined;
+  const plugin = findPlugin(pluginId);
   const all = listPlugins();
 
   return (
-    <PageShell className="text-text-primary">
-      <h1 className="text-2xl font-semibold mb-3">Canvas host — phase 1 scaffold</h1>
-      <p className="text-text-secondary mb-6">
-        Plugin: <code className="bg-bg-card px-2 py-0.5 rounded">{pluginId ?? '(none — pass ?plugin=<id>)'}</code>
-      </p>
+    <div className="relative">
+      <PluginPicker plugins={all} activeId={pluginId} />
+      {!plugin && <NotFound pluginId={pluginId} />}
+      {plugin?.kind === 'three' && <ThreeHost mount={plugin.mount} key={plugin.id} />}
+      {plugin?.kind === 'react' && <plugin.renderer />}
+    </div>
+  );
+}
 
-      {pluginId && !plugin && (
-        <div className="p-4 rounded-xl border border-warning/30 bg-warning/10 text-warning">
-          Plugin <code>{pluginId}</code> not found in registry. The populator will fill this in.
-        </div>
-      )}
+function PluginPicker({ plugins, activeId }: { plugins: CanvasPlugin[]; activeId: string }) {
+  return (
+    <div className="absolute top-3 right-3 z-30 flex flex-wrap gap-1 max-w-[60vw] justify-end">
+      {plugins.map((p) => {
+        const active = p.id === activeId;
+        return (
+          <Link
+            key={p.id}
+            to={`/?plugin=${p.id}`}
+            className={`px-2.5 py-1 rounded-md text-xs font-mono backdrop-blur-xl border transition-colors ${
+              active
+                ? 'bg-accent/20 text-accent border-accent/40'
+                : 'bg-black/50 text-text-secondary border-white/10 hover:border-accent/40 hover:text-accent'
+            }`}
+          >
+            {p.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
 
-      {plugin && (
-        <div className="p-4 rounded-xl border border-border bg-bg-card">
-          <div className="text-sm text-text-muted mb-2">Resolved plugin</div>
-          <div className="font-mono text-accent">{plugin.id}</div>
-          <div className="text-text-secondary">{plugin.label} · kind={plugin.kind}</div>
-        </div>
-      )}
+function NotFound({ pluginId }: { pluginId: string }) {
+  return (
+    <div className="p-8 text-text-secondary">
+      <div className="p-4 rounded-xl border border-warning/30 bg-warning/10 text-warning">
+        Plugin <code>{pluginId}</code> not found in registry.
+      </div>
+    </div>
+  );
+}
 
-      <section className="mt-10">
-        <h2 className="text-lg font-semibold mb-2">Registered plugins</h2>
-        {all.length === 0 ? (
-          <p className="text-text-muted">None yet — registry is empty until the populator runs.</p>
-        ) : (
-          <ul className="space-y-1 text-sm font-mono">
-            {all.map((p) => (
-              <li key={p.id}>
-                <span className="text-accent">{p.id}</span>
-                <span className="text-text-muted"> — {p.label} ({p.kind})</span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-    </PageShell>
+function ThreeHost({ mount }: { mount: SceneMount }) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap) return;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x000000);
+    const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 100);
+    camera.position.z = 3;
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    const light = new THREE.PointLight(0xffffff, 50, 100);
+    light.position.set(3, 3, 5);
+    scene.add(light);
+    scene.add(new THREE.AmbientLight(0x404060, 1));
+
+    const setSize = () => {
+      const w = wrap.clientWidth;
+      const h = wrap.clientHeight;
+      if (w > 0 && h > 0) {
+        renderer.setSize(w, h, false);
+        camera.aspect = w / h;
+        camera.updateProjectionMatrix();
+      }
+    };
+    setSize();
+    const ro = new ResizeObserver(setSize);
+    ro.observe(wrap);
+
+    const instance = mount({ scene, camera, renderer, THREE });
+    let raf = 0;
+    let disposed = false;
+
+    const tick = () => {
+      if (disposed) return;
+      instance.tick?.();
+      renderer.render(scene, camera);
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      instance.dispose?.();
+      renderer.dispose();
+    };
+  }, [mount]);
+
+  return (
+    <div ref={wrapRef} className="w-full h-[calc(100vh-64px)] bg-black overflow-hidden">
+      <canvas ref={canvasRef} className="w-full h-full block" />
+    </div>
   );
 }

--- a/apps/canvas/src/plugins/react/MapPlugin.tsx
+++ b/apps/canvas/src/plugins/react/MapPlugin.tsx
@@ -1,0 +1,56 @@
+import { useMemo, useState } from 'react';
+import { KnowledgeMap } from 'knowledge-map-3d';
+import { usePlanetsData } from '../../hooks/usePlanetsData';
+import { usePlanetsSearch } from '../../hooks/usePlanetsSearch';
+import { PlanetsLoading, PlanetsEmpty } from '../../components/planets/PlanetsEmpty';
+import { PlanetsHUD } from '../../components/planets/PlanetsHUD';
+import { TYPE_COLORS } from '../../lib/type-colors';
+
+export function MapPlugin() {
+  const data = usePlanetsData();
+  const search = usePlanetsSearch();
+  const [visibleTypes, setVisibleTypes] = useState<Set<string>>(() => new Set(Object.keys(TYPE_COLORS)));
+
+  const filteredDocs = useMemo(
+    () => data.documents.filter((d) => visibleTypes.has(d.type)),
+    [data.documents, visibleTypes],
+  );
+
+  const toggleType = (t: string) =>
+    setVisibleTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(t)) next.delete(t);
+      else next.add(t);
+      return next;
+    });
+
+  if (data.loading) return <PlanetsLoading />;
+  if (data.error) return <PlanetsEmpty message={data.error} />;
+  if (data.documents.length === 0) return <PlanetsEmpty />;
+
+  return (
+    <div className="relative h-[calc(100vh-64px)] overflow-hidden bg-black">
+      <KnowledgeMap
+        documents={filteredDocs}
+        clusters={data.clusters}
+        nebulae={data.nebulae}
+        highlightIds={search.matchIds}
+        onDocumentClick={(doc) => {
+          window.location.href = `/doc/${encodeURIComponent(doc.id)}`;
+        }}
+        typeColors={TYPE_COLORS}
+        embedded
+        heightMode="auto"
+        className="w-full h-full"
+      />
+      <PlanetsHUD
+        query={search.query}
+        onQueryChange={search.setQuery}
+        onClear={search.clear}
+        matchCount={search.matchIds.size}
+        visibleTypes={visibleTypes}
+        onToggleType={toggleType}
+      />
+    </div>
+  );
+}

--- a/apps/canvas/src/plugins/react/PlanetsPlugin.tsx
+++ b/apps/canvas/src/plugins/react/PlanetsPlugin.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useMemo, useState } from 'react';
+import { usePlanetsData } from '../../hooks/usePlanetsData';
+import { usePlanetsSearch } from '../../hooks/usePlanetsSearch';
+import { PlanetsCanvas } from '../../components/planets/PlanetsCanvas';
+import { PlanetsSidebar } from '../../components/planets/PlanetsSidebar';
+import { PlanetsHUD } from '../../components/planets/PlanetsHUD';
+import { PlanetsLoading, PlanetsEmpty } from '../../components/planets/PlanetsEmpty';
+import { NebulaLegend } from '../../components/planets/NebulaLegend';
+import { TYPE_COLORS } from '../../lib/type-colors';
+
+export function PlanetsPlugin() {
+  const data = usePlanetsData();
+  const search = usePlanetsSearch();
+  const [visibleTypes, setVisibleTypes] = useState<Set<string>>(() => new Set(Object.keys(TYPE_COLORS)));
+  const [selectedProject, setSelectedProject] = useState<string | null>(null);
+
+  const toggleType = useCallback((t: string) => {
+    setVisibleTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(t)) next.delete(t);
+      else next.add(t);
+      return next;
+    });
+  }, []);
+
+  const filteredDocs = useMemo(
+    () =>
+      data.documents.filter(
+        (d) => visibleTypes.has(d.type) && (!selectedProject || d.project === selectedProject),
+      ),
+    [data.documents, visibleTypes, selectedProject],
+  );
+
+  const typeCounts = useMemo(() => {
+    const c: Record<string, number> = {};
+    for (const d of data.documents) c[d.type] = (c[d.type] || 0) + 1;
+    return c;
+  }, [data.documents]);
+
+  if (data.loading) return <PlanetsLoading />;
+  if (data.error) return <PlanetsEmpty message={data.error} />;
+  if (data.documents.length === 0) return <PlanetsEmpty />;
+
+  return (
+    <div className="flex h-[calc(100vh-64px)] overflow-hidden bg-black">
+      <div className="flex-1 relative overflow-hidden">
+        <PlanetsCanvas
+          documents={filteredDocs}
+          clusters={data.clusters}
+          nebulae={data.nebulae}
+          highlightIds={search.matchIds}
+          onDocumentClick={(doc) => {
+            window.location.href = `/doc/${encodeURIComponent(doc.id)}`;
+          }}
+        />
+        <PlanetsHUD
+          query={search.query}
+          onQueryChange={search.setQuery}
+          onClear={search.clear}
+          matchCount={search.matchIds.size}
+          visibleTypes={visibleTypes}
+          onToggleType={toggleType}
+        />
+        <NebulaLegend />
+      </div>
+      <PlanetsSidebar
+        stats={data.stats}
+        clusters={data.clusters}
+        totalDocs={data.documents.length}
+        typeCounts={typeCounts}
+        matchCount={search.matchIds.size}
+        selectedProject={selectedProject}
+        onSelectProject={setSelectedProject}
+        model={data.model}
+        onSetModel={data.setModel}
+      />
+    </div>
+  );
+}

--- a/apps/canvas/src/plugins/three/cube.ts
+++ b/apps/canvas/src/plugins/three/cube.ts
@@ -1,0 +1,24 @@
+import type { SceneMount } from '../../lib/plugins/registry';
+
+export const mount: SceneMount = ({ scene, THREE }) => {
+  const geometry = new THREE.BoxGeometry(1, 1, 1);
+  const material = new THREE.MeshStandardMaterial({
+    color: 0x7c3aed,
+    roughness: 0.4,
+    metalness: 0.2,
+  });
+  const cube = new THREE.Mesh(geometry, material);
+  scene.add(cube);
+
+  return {
+    tick() {
+      cube.rotation.x += 0.01;
+      cube.rotation.y += 0.012;
+    },
+    dispose() {
+      scene.remove(cube);
+      geometry.dispose();
+      material.dispose();
+    },
+  };
+};

--- a/apps/canvas/src/plugins/three/galaxy.ts
+++ b/apps/canvas/src/plugins/three/galaxy.ts
@@ -1,0 +1,60 @@
+import type { SceneMount } from '../../lib/plugins/registry';
+
+export const mount: SceneMount = ({ scene, camera, THREE }) => {
+  camera.position.z = 6;
+
+  const COUNT = 4000;
+  const positions = new Float32Array(COUNT * 3);
+  const colors = new Float32Array(COUNT * 3);
+  const radii = new Float32Array(COUNT);
+  const palette = [
+    new THREE.Color(0x7c3aed),
+    new THREE.Color(0x22d3ee),
+    new THREE.Color(0xf472b6),
+  ];
+
+  for (let i = 0; i < COUNT; i++) {
+    const r = Math.pow(Math.random(), 0.5) * 4;
+    const branch = (i % 3) * ((2 * Math.PI) / 3);
+    const spin = r * 1.2;
+    const theta = branch + spin + (Math.random() - 0.5) * 0.4;
+    const y = (Math.random() - 0.5) * 0.3 * (1 - r / 4);
+
+    positions[i * 3 + 0] = Math.cos(theta) * r;
+    positions[i * 3 + 1] = y;
+    positions[i * 3 + 2] = Math.sin(theta) * r;
+
+    const c = palette[i % palette.length];
+    colors[i * 3 + 0] = c.r;
+    colors[i * 3 + 1] = c.g;
+    colors[i * 3 + 2] = c.b;
+    radii[i] = r;
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+
+  const material = new THREE.PointsMaterial({
+    size: 0.04,
+    vertexColors: true,
+    transparent: true,
+    opacity: 0.9,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+  });
+
+  const points = new THREE.Points(geometry, material);
+  scene.add(points);
+
+  return {
+    tick() {
+      points.rotation.y += 0.0025;
+    },
+    dispose() {
+      scene.remove(points);
+      geometry.dispose();
+      material.dispose();
+    },
+  };
+};

--- a/apps/canvas/src/plugins/three/graph3d.ts
+++ b/apps/canvas/src/plugins/three/graph3d.ts
@@ -1,0 +1,118 @@
+import type { SceneMount } from '../../lib/plugins/registry';
+import { apiUrl } from '../../api/host';
+
+type GraphNode = { id: string; type: string; concepts?: string[] };
+
+const FALLBACK_NODES: GraphNode[] = [
+  { id: 'p1', type: 'principle', concepts: ['nothing-deleted'] },
+  { id: 'p2', type: 'principle', concepts: ['patterns-over-intentions'] },
+  { id: 'p3', type: 'principle', concepts: ['external-brain'] },
+  { id: 'p4', type: 'principle', concepts: ['curiosity'] },
+  { id: 'p5', type: 'principle', concepts: ['form-formless'] },
+  { id: 'p6', type: 'principle', concepts: ['oracle-rule-6'] },
+  { id: 'l1', type: 'learning', concepts: ['federation'] },
+  { id: 'l2', type: 'learning', concepts: ['federation', 'maw'] },
+  { id: 'l3', type: 'learning', concepts: ['three-js'] },
+  { id: 'l4', type: 'learning', concepts: ['three-js', 'plugins'] },
+  { id: 'l5', type: 'learning', concepts: ['plugins'] },
+  { id: 'l6', type: 'learning', concepts: ['astro'] },
+  { id: 'l7', type: 'learning', concepts: ['astro', 'bun'] },
+  { id: 'l8', type: 'learning', concepts: ['bun'] },
+  { id: 'l9', type: 'learning', concepts: ['wireguard'] },
+  { id: 'l10', type: 'learning', concepts: ['ssh', 'wireguard'] },
+  { id: 'r1', type: 'retro', concepts: ['federation'] },
+  { id: 'r2', type: 'retro', concepts: ['plugins'] },
+  { id: 'r3', type: 'retro', concepts: ['oracle'] },
+];
+
+const TYPE_COLOR: Record<string, number> = {
+  principle: 0x7c3aed,
+  learning: 0x22d3ee,
+  retro: 0xf472b6,
+};
+const DEFAULT_COLOR = 0x64748b;
+const RADIUS = 5;
+
+async function fetchGraph(): Promise<GraphNode[]> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), 2000);
+  try {
+    const res = await fetch(apiUrl('/api/graph'), { signal: ctrl.signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (!data?.nodes?.length) throw new Error('empty');
+    return data.nodes;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function anchorFor(index: number, total: number): [number, number, number] {
+  const phi = Math.acos(1 - (2 * (index + 0.5)) / total);
+  const theta = Math.PI * (1 + Math.sqrt(5)) * index;
+  return [
+    RADIUS * Math.sin(phi) * Math.cos(theta),
+    RADIUS * Math.sin(phi) * Math.sin(theta),
+    RADIUS * Math.cos(phi),
+  ];
+}
+
+export const mount: SceneMount = ({ scene, camera, THREE }) => {
+  camera.position.z = 12;
+
+  const geometry = new THREE.BufferGeometry();
+  const material = new THREE.PointsMaterial({
+    size: 0.12,
+    vertexColors: true,
+    transparent: true,
+    opacity: 0.95,
+    depthWrite: false,
+  });
+  const points = new THREE.Points(geometry, material);
+  scene.add(points);
+
+  const build = (nodes: GraphNode[]) => {
+    const concepts: string[] = [];
+    const conceptIdx = new Map<string, number>();
+    for (const n of nodes) {
+      const c = n.concepts?.[0] ?? '_';
+      if (!conceptIdx.has(c)) {
+        conceptIdx.set(c, concepts.length);
+        concepts.push(c);
+      }
+    }
+    const positions = new Float32Array(nodes.length * 3);
+    const colors = new Float32Array(nodes.length * 3);
+    const tmpColor = new THREE.Color();
+    for (let i = 0; i < nodes.length; i++) {
+      const n = nodes[i];
+      const ci = conceptIdx.get(n.concepts?.[0] ?? '_')!;
+      const [ax, ay, az] = anchorFor(ci, concepts.length);
+      positions[i * 3 + 0] = ax + (Math.random() - 0.5) * 0.6;
+      positions[i * 3 + 1] = ay + (Math.random() - 0.5) * 0.6;
+      positions[i * 3 + 2] = az + (Math.random() - 0.5) * 0.6;
+      tmpColor.setHex(TYPE_COLOR[n.type] ?? DEFAULT_COLOR);
+      colors[i * 3 + 0] = tmpColor.r;
+      colors[i * 3 + 1] = tmpColor.g;
+      colors[i * 3 + 2] = tmpColor.b;
+    }
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+  };
+
+  build(FALLBACK_NODES);
+  fetchGraph()
+    .then((nodes) => build(nodes))
+    .catch(() => {});
+
+  return {
+    tick() {
+      points.rotation.y += 0.0015;
+    },
+    dispose() {
+      scene.remove(points);
+      geometry.dispose();
+      material.dispose();
+    },
+  };
+};

--- a/apps/canvas/src/plugins/three/map3d.ts
+++ b/apps/canvas/src/plugins/three/map3d.ts
@@ -1,0 +1,96 @@
+import type { SceneMount } from '../../lib/plugins/registry';
+import { apiUrl } from '../../api/host';
+
+type Doc = { id: string; type: string; x?: number; y?: number; z?: number; concepts: string[] };
+
+const TYPE_COLOR: Record<string, number> = {
+  principle: 0x7c3aed,
+  learning: 0x22d3ee,
+  retro: 0xf472b6,
+};
+const DEFAULT_COLOR = 0x64748b;
+const SPREAD = 8;
+
+async function fetchMap(): Promise<Doc[]> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), 3000);
+  try {
+    const res = await fetch(apiUrl('/api/map3d?limit=5000'), { signal: ctrl.signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (!data?.documents?.length) throw new Error('empty');
+    return data.documents;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function randomSphere(n: number): Doc[] {
+  const docs: Doc[] = [];
+  for (let i = 0; i < n; i++) {
+    const u = Math.random();
+    const v = Math.random();
+    const theta = 2 * Math.PI * u;
+    const phi = Math.acos(2 * v - 1);
+    const r = Math.cbrt(Math.random()) * 3;
+    docs.push({
+      id: `fallback-${i}`,
+      type: 'fallback',
+      x: (r * Math.sin(phi) * Math.cos(theta)) / SPREAD,
+      y: (r * Math.sin(phi) * Math.sin(theta)) / SPREAD,
+      z: (r * Math.cos(phi)) / SPREAD,
+      concepts: [],
+    });
+  }
+  return docs;
+}
+
+export const mount: SceneMount = ({ scene, camera, THREE }) => {
+  camera.position.z = 8;
+
+  const geometry = new THREE.BufferGeometry();
+  const material = new THREE.PointsMaterial({
+    size: 0.06,
+    vertexColors: true,
+    transparent: true,
+    opacity: 0.9,
+    depthWrite: false,
+    sizeAttenuation: true,
+  });
+  const points = new THREE.Points(geometry, material);
+  scene.add(points);
+
+  const build = (docs: Doc[]) => {
+    const positions = new Float32Array(docs.length * 3);
+    const colors = new Float32Array(docs.length * 3);
+    const tmpColor = new THREE.Color();
+    for (let i = 0; i < docs.length; i++) {
+      const d = docs[i];
+      positions[i * 3 + 0] = (d.x ?? 0) * SPREAD;
+      positions[i * 3 + 1] = (d.y ?? 0) * SPREAD;
+      positions[i * 3 + 2] = (d.z ?? 0) * SPREAD;
+      tmpColor.setHex(TYPE_COLOR[d.type] ?? DEFAULT_COLOR);
+      colors[i * 3 + 0] = tmpColor.r;
+      colors[i * 3 + 1] = tmpColor.g;
+      colors[i * 3 + 2] = tmpColor.b;
+    }
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+  };
+
+  build(randomSphere(100));
+  fetchMap()
+    .then((docs) => build(docs))
+    .catch(() => {});
+
+  return {
+    tick() {
+      points.rotation.y += 0.0008;
+    },
+    dispose() {
+      scene.remove(points);
+      geometry.dispose();
+      material.dispose();
+    },
+  };
+};

--- a/apps/canvas/src/plugins/three/solar.ts
+++ b/apps/canvas/src/plugins/three/solar.ts
@@ -1,0 +1,64 @@
+import type { SceneMount } from '../../lib/plugins/registry';
+
+export const mount: SceneMount = ({ scene, camera, THREE }) => {
+  camera.position.set(0, 4, 12);
+  camera.lookAt(0, 0, 0);
+
+  const sunGeo = new THREE.SphereGeometry(1.2, 32, 32);
+  const sunMat = new THREE.MeshBasicMaterial({ color: 0xfacc15 });
+  const sun = new THREE.Mesh(sunGeo, sunMat);
+  scene.add(sun);
+
+  const sunLight = new THREE.PointLight(0xfacc15, 200, 50);
+  sunLight.position.set(0, 0, 0);
+  scene.add(sunLight);
+
+  const ambient = new THREE.AmbientLight(0x222233, 1);
+  scene.add(ambient);
+
+  const planetSpecs = [
+    { radius: 2.2, size: 0.18, color: 0x94a3b8, speed: 0.018 },
+    { radius: 3.1, size: 0.32, color: 0xf472b6, speed: 0.013 },
+    { radius: 4.2, size: 0.38, color: 0x22d3ee, speed: 0.009 },
+    { radius: 5.6, size: 0.28, color: 0xef4444, speed: 0.006 },
+    { radius: 7.0, size: 0.55, color: 0x7c3aed, speed: 0.004 },
+  ];
+
+  const planets = planetSpecs.map((spec) => {
+    const group = new THREE.Group();
+    const geo = new THREE.SphereGeometry(spec.size, 24, 24);
+    const mat = new THREE.MeshStandardMaterial({
+      color: spec.color,
+      roughness: 0.7,
+      metalness: 0.1,
+    });
+    const mesh = new THREE.Mesh(geo, mat);
+    mesh.position.x = spec.radius;
+    group.add(mesh);
+    group.rotation.y = Math.random() * Math.PI * 2;
+    scene.add(group);
+    return { group, geo, mat, mesh, speed: spec.speed };
+  });
+
+  return {
+    tick() {
+      sun.rotation.y += 0.004;
+      for (const p of planets) {
+        p.group.rotation.y += p.speed;
+        p.mesh.rotation.y += 0.02;
+      }
+    },
+    dispose() {
+      scene.remove(sun);
+      scene.remove(sunLight);
+      scene.remove(ambient);
+      sunGeo.dispose();
+      sunMat.dispose();
+      for (const p of planets) {
+        scene.remove(p.group);
+        p.geo.dispose();
+        p.mat.dispose();
+      }
+    },
+  };
+};

--- a/apps/canvas/src/plugins/three/torus.ts
+++ b/apps/canvas/src/plugins/three/torus.ts
@@ -1,0 +1,26 @@
+import type { SceneMount } from '../../lib/plugins/registry';
+
+export const mount: SceneMount = ({ scene, THREE }) => {
+  const geometry = new THREE.TorusKnotGeometry(1, 0.3, 128, 16);
+  const material = new THREE.MeshStandardMaterial({
+    color: 0x22d3ee,
+    roughness: 0.2,
+    metalness: 0.6,
+    emissive: 0x164e63,
+    emissiveIntensity: 0.3,
+  });
+  const knot = new THREE.Mesh(geometry, material);
+  scene.add(knot);
+
+  return {
+    tick() {
+      knot.rotation.x += 0.006;
+      knot.rotation.y += 0.008;
+    },
+    dispose() {
+      scene.remove(knot);
+      geometry.dispose();
+      material.dispose();
+    },
+  };
+};

--- a/apps/canvas/src/plugins/three/wave.ts
+++ b/apps/canvas/src/plugins/three/wave.ts
@@ -1,0 +1,42 @@
+import type { SceneMount } from '../../lib/plugins/registry';
+
+export const mount: SceneMount = ({ scene, camera, THREE }) => {
+  camera.position.set(0, 3, 5);
+  camera.lookAt(0, 0, 0);
+
+  const geometry = new THREE.PlaneGeometry(10, 10, 64, 64);
+  const material = new THREE.MeshStandardMaterial({
+    color: 0x22d3ee,
+    wireframe: true,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.rotation.x = -Math.PI / 2.4;
+  scene.add(mesh);
+
+  const position = geometry.attributes.position;
+  const original = new Float32Array(position.array.length);
+  original.set(position.array);
+
+  let time = 0;
+
+  return {
+    tick() {
+      time += 0.03;
+      const arr = position.array as Float32Array;
+      for (let i = 0; i < position.count; i++) {
+        const ix = i * 3;
+        const x = original[ix];
+        const y = original[ix + 1];
+        arr[ix + 2] = Math.sin(x + time) * Math.cos(y + time) * 0.5;
+      }
+      position.needsUpdate = true;
+      geometry.computeVertexNormals();
+      mesh.rotation.z += 0.002;
+    },
+    dispose() {
+      scene.remove(mesh);
+      geometry.dispose();
+      material.dispose();
+    },
+  };
+};

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/three": "^0.184.0",
         "@ui-oracle/shared-ui": "workspace:*",
+        "knowledge-map-3d": "github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.11.0",
@@ -1388,6 +1389,8 @@
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "oracle-studio/@types/three": ["@types/three@0.182.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.22.0" } }, "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q=="],
+
+    "oracle-studio/knowledge-map-3d": ["knowledge-map-3d@github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D#4dfd12d", { "peerDependencies": { "react": ">=18", "react-dom": ">=18", "three": ">=0.150.0" } }, "Bombbaza-Multi-Planet-System-Knowledge-Map-3D-4dfd12d", "sha512-ddXFX0qW9mEd+3JaixN8wwGwsvaFKz0foCXz+ioPQug+s84lSfZGYdJUfyB+rSnpCcnf275WQhBOSR9JYxUIlg=="],
 
     "oracle-studio/three": ["three@0.182.0", "", {}, "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ=="],
 


### PR DESCRIPTION
Populate `apps/canvas` plugin registry with 9 plugins — default is `map`.

## Registered plugins

| id | kind | source |
|----|------|--------|
| map | react | knowledge-map-3d (no sidebar) |
| planets | react | knowledge-map-3d + sidebar + HUD + nebulae |
| wave | three | ported from oracle-studio@6efff7d |
| cube | three | ported |
| torus | three | ported |
| galaxy | three | ported |
| solar | three | ported |
| graph3d | three | ported |
| map3d | three | ported |

## Wiring

- `apps/canvas/src/plugins/three/*.ts` — 7 Three.js modules, each exports `mount: SceneMount`.
- `apps/canvas/src/plugins/react/{MapPlugin,PlanetsPlugin}.tsx` — React plugins composed from ported `lib/planets` + `hooks/usePlanets*` + `components/planets/*`.
- `apps/canvas/src/pages/CanvasHost.tsx` — reads `?plugin=<id>`, defaults to `map`; dispatches to Three scene host or React renderer; plugin picker pinned top-right.
- `apps/canvas/package.json` — adds `knowledge-map-3d` (GitHub tarball, reusing root `patchedDependencies`).

Every file ≤ 200 lines.

Closes phase 1b of Soul-Brews-Studio/arra-oracle-v3#950.