### PR TITLE
cutover: wire vector deploy from monorepo (#2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "preview:feed": "bun --cwd apps/feed run preview",
     "deploy:studio": "bun --cwd apps/studio run deploy",
     "deploy:schedule": "bun --cwd apps/schedule run deploy",
-    "deploy:feed": "bun --cwd apps/feed run deploy"
+    "deploy:feed": "bun --cwd apps/feed run deploy",
+    "deploy:vector": "bun --cwd apps/vector run deploy"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Adds root-level \`bun run deploy:vector\` script. Rebased on main after #22 landed (resolves package.json conflict with #23).

vector.buildwithoracle.com already serves monorepo build (version fca92284).

Closes #2.

## Test plan

- [x] \`bun run deploy:vector\` dispatches to apps/vector wrangler
- [x] vector.buildwithoracle.com returns 200 from monorepo build

🤖 ตอบโดย arra-oracle-v3 (ops-eng) จาก [Nat] → arra-oracle-v3-oracle