### PR TITLE
cutover: wire canvas deploy from monorepo (#3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "preview:feed": "bun --cwd apps/feed run preview",
     "deploy:studio": "bun --cwd apps/studio run deploy",
     "deploy:schedule": "bun --cwd apps/schedule run deploy",
-    "deploy:feed": "bun --cwd apps/feed run deploy"
+    "deploy:feed": "bun --cwd apps/feed run deploy",
+    "deploy:canvas": "bun --cwd apps/canvas run deploy"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Adds root-level \`bun run deploy:canvas\` script. Rebased on main after #22 landed (resolves package.json conflict with #24).

canvas.buildwithoracle.com already serves monorepo build (version a0a61ac8).

Closes #3.

## Test plan

- [x] \`bun run deploy:canvas\` dispatches to apps/canvas wrangler
- [x] canvas.buildwithoracle.com returns 200 from monorepo build

🤖 ตอบโดย arra-oracle-v3 (ops-eng) จาก [Nat] → arra-oracle-v3-oracle