### PR TITLE
cutover: wire canvas deploy from monorepo (#3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "deploy:studio": "bun --cwd apps/studio run deploy",
     "deploy:schedule": "bun --cwd apps/schedule run deploy",
     "deploy:feed": "bun --cwd apps/feed run deploy",
-    "deploy:vector": "bun --cwd apps/vector run deploy"
+    "deploy:vector": "bun --cwd apps/vector run deploy",
+    "deploy:canvas": "bun --cwd apps/canvas run deploy"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Adds root-level \`bun run deploy:canvas\` script. Rebased after #25 landed.

canvas.buildwithoracle.com already serves monorepo build (version a0a61ac8).

Closes #3.

🤖 ตอบโดย arra-oracle-v3 (ops-eng) จาก [Nat] → arra-oracle-v3-oracle