### PR TITLE
feat(studio): #30 inline parent picker on menu rows

### DIFF
--- a/apps/studio/src/components/menu/TreeRow.tsx
+++ b/apps/studio/src/components/menu/TreeRow.tsx
@@ -15,13 +15,14 @@ interface Props {
   item: MenuItem;
   depth: number;
   hasChildren: boolean;
+  parentOptions: MenuItem[];
   onPatch: (id: number, patch: Partial<MenuItem>) => void;
   onEdit: (item: MenuItem) => void;
   onReset: (id: number) => void;
   onDelete: (id: number) => void;
 }
 
-export function TreeRow({ item, depth, hasChildren, onPatch, onEdit, onReset, onDelete }: Props) {
+export function TreeRow({ item, depth, hasChildren, parentOptions, onPatch, onEdit, onReset, onDelete }: Props) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: item.id });
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -58,6 +59,17 @@ export function TreeRow({ item, depth, hasChildren, onPatch, onEdit, onReset, on
       <span className="font-medium flex-none w-40 truncate">{item.label}</span>
       <code className="text-xs text-text-secondary font-mono flex-1 truncate">{item.path}</code>
       <span className={`px-2 py-0.5 rounded text-[10px] border ${GROUP_COLORS[item.groupKey] ?? ''}`}>{item.groupKey}</span>
+      <select
+        value={item.parentId ?? ''}
+        onChange={(e) => onPatch(item.id, { parentId: e.target.value === '' ? null : Number(e.target.value) })}
+        className="bg-bg-base border border-border rounded px-2 py-1 text-[11px] max-w-[140px]"
+        title="Parent"
+      >
+        <option value="">(top-level)</option>
+        {parentOptions.map((p) => (
+          <option key={p.id} value={p.id}>{p.label}</option>
+        ))}
+      </select>
       <span className={`px-2 py-0.5 rounded text-[10px] ${SOURCE_COLORS[item.source] ?? ''}`}>{item.source}</span>
       {host && (
         <span className="px-2 py-0.5 rounded text-[10px] bg-indigo-500/10 text-indigo-300 border border-indigo-500/30 font-mono" title="Host filter">

--- a/apps/studio/src/pages/MenuEditor.tsx
+++ b/apps/studio/src/pages/MenuEditor.tsx
@@ -102,6 +102,27 @@ export function MenuEditor() {
     return set;
   }, [items]);
 
+  // Parent picker options = items whose path is '#' (menu-parent containers like Tools, Canvas).
+  const parentContainers = useMemo(
+    () => items.filter((i) => i.path === '#').sort((a, b) => a.label.localeCompare(b.label)),
+    [items],
+  );
+
+  function parentOptionsFor(id: number): MenuItem[] {
+    const descendants = new Set<number>([id]);
+    let grew = true;
+    while (grew) {
+      grew = false;
+      for (const it of items) {
+        if (it.parentId != null && descendants.has(it.parentId) && !descendants.has(it.id)) {
+          descendants.add(it.id);
+          grew = true;
+        }
+      }
+    }
+    return parentContainers.filter((p) => !descendants.has(p.id));
+  }
+
   async function handleDragEnd(parentId: number | null, e: DragEndEvent) {
     const { active, over } = e;
     if (!over || active.id === over.id) return;
@@ -142,6 +163,7 @@ export function MenuEditor() {
                   item={it}
                   depth={depth}
                   hasChildren={hasChildren.has(it.id)}
+                  parentOptions={parentOptionsFor(it.id)}
                   onPatch={patchItem}
                   onEdit={setEditing}
                   onReset={resetItem}


### PR DESCRIPTION
## Summary
- Adds a parent `<select>` column to each row in the studio menu editor
- Options are items with `path='#'` (menu-parent containers like Tools, Canvas); null option = top-level
- Filters out the current row and its descendants to prevent cycles
- PATCHes `parentId` via the existing `onPatch` pipeline — DnD tree preview reflows after reparent

## Scope
Closes first half of #30 (parent picker). Query editor column follows in a separate PR once #957 backend `query` JSON column lands.

## Test plan
- [ ] Reparent a row via the new select → tree reflows, no page reload needed
- [ ] Top-level option returns the row to root
- [ ] Current row and descendants not offered as parent options
- [ ] Refresh page → new parent persists

🤖 ตอบโดย arra-oracle-v3 จาก Nat → arra-oracle-v3-oracle

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>