### PR TITLE
feat(header): #28 nested submenu render — children on parent items

### DIFF
--- a/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
@@ -20,6 +20,25 @@ const DEFAULT_NAV: NavSet = {
     { path: '/sessions', label: 'Sessions' },
     { path: '/plugins', label: 'Plugins' },
     { path: '/activity?tab=searches', label: 'Activity' },
+    {
+      path: '/',
+      label: 'Canvas',
+      studio: 'canvas.buildwithoracle.com',
+      children: [
+        {
+          path: '/canvas?plugin=map',
+          label: 'Map',
+          studio: 'canvas.buildwithoracle.com',
+          query: { plugin: 'map' },
+        },
+        {
+          path: '/canvas?plugin=planets',
+          label: 'Planets',
+          studio: 'canvas.buildwithoracle.com',
+          query: { plugin: 'planets' },
+        },
+      ],
+    },
   ],
   tools: [
     { path: '/playground', label: 'Playground' },
@@ -27,18 +46,6 @@ const DEFAULT_NAV: NavSet = {
     { path: '/evolution', label: 'Evolution' },
     { path: '/traces', label: 'Traces' },
     { path: '/schedule', label: 'Schedule' },
-    {
-      path: '/canvas?plugin=map',
-      label: 'Map',
-      studio: 'canvas.buildwithoracle.com',
-      query: { plugin: 'map' },
-    },
-    {
-      path: '/canvas?plugin=planets',
-      label: 'Planets',
-      studio: 'canvas.buildwithoracle.com',
-      query: { plugin: 'planets' },
-    },
   ],
 };
 

--- a/packages/shared-ui/src/components/AppHeader/MainNav.tsx
+++ b/packages/shared-ui/src/components/AppHeader/MainNav.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from 'react-router-dom';
 import type { CrossOriginResolver, NavItem } from './nav-types';
 import { isActivePath } from './nav-types';
+import { NavDisclosure } from './NavDisclosure';
 
 interface MainNavProps {
   items: NavItem[];
@@ -9,7 +10,8 @@ interface MainNavProps {
 
 /**
  * Top-level nav items. Renders either internal `<Link>` or cross-origin `<a>`
- * based on `crossOriginHref(item)`. Fully host-agnostic.
+ * based on `crossOriginHref(item)`. Items with `children` render a disclosure
+ * panel (hover desktop, tap mobile). Fully host-agnostic.
  */
 export function MainNav({ items, crossOriginHref }: MainNavProps) {
   const location = useLocation();
@@ -17,6 +19,15 @@ export function MainNav({ items, crossOriginHref }: MainNavProps) {
   return (
     <>
       {items.map((item) => {
+        if (item.children && item.children.length > 0) {
+          return (
+            <NavDisclosure
+              key={item.path + ':' + item.label}
+              item={item}
+              crossOriginHref={crossOriginHref}
+            />
+          );
+        }
         const href = crossOriginHref(item);
         if (href) {
           return (

--- a/packages/shared-ui/src/components/AppHeader/NavDisclosure.tsx
+++ b/packages/shared-ui/src/components/AppHeader/NavDisclosure.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import type { CrossOriginResolver, NavItem } from './nav-types';
+import { isActivePath } from './nav-types';
+
+interface NavDisclosureProps {
+  item: NavItem;
+  crossOriginHref: CrossOriginResolver;
+}
+
+/**
+ * Parent nav item with a submenu panel. Desktop: hover opens. Mobile
+ * (coarse pointer / ≤640px): tap the chevron to toggle. The parent label
+ * itself navigates to `item.path` (or its cross-origin href) so a Canvas
+ * parent with `studio` lands at the studio root.
+ */
+export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
+  const location = useLocation();
+  const [open, setOpen] = useState(false);
+  const [isCoarse, setIsCoarse] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(hover: none), (max-width: 640px)');
+    const sync = () => setIsCoarse(mq.matches);
+    sync();
+    mq.addEventListener?.('change', sync);
+    return () => mq.removeEventListener?.('change', sync);
+  }, []);
+
+  const children = item.children ?? [];
+  const parentHref = crossOriginHref(item);
+  const hasRealPath = item.path && item.path !== '#';
+  const anyActive = isActivePath(location, item.path)
+    || children.some((c) => isActivePath(location, c.path));
+
+  const labelClass = `px-2.5 py-1.5 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
+    anyActive
+      ? 'bg-accent/15 text-accent font-semibold border border-accent/20'
+      : 'text-text-secondary hover:bg-bg-card hover:text-accent border border-transparent'
+  }`;
+
+  const renderParentLabel = () => {
+    if (!hasRealPath) {
+      return (
+        <button
+          type="button"
+          className={`${labelClass} bg-transparent cursor-pointer font-[inherit]`}
+          onClick={() => isCoarse && setOpen((v) => !v)}
+        >
+          {item.label} <span aria-hidden="true">▸</span>
+        </button>
+      );
+    }
+    if (parentHref) {
+      return (
+        <a href={parentHref} className={labelClass}>
+          {item.label} <span aria-hidden="true">▸</span>
+        </a>
+      );
+    }
+    return (
+      <Link to={item.path} className={labelClass}>
+        {item.label} <span aria-hidden="true">▸</span>
+      </Link>
+    );
+  };
+
+  return (
+    <div
+      className="relative inline-flex items-center"
+      onMouseEnter={() => !isCoarse && setOpen(true)}
+      onMouseLeave={() => !isCoarse && setOpen(false)}
+    >
+      <span className="inline-flex items-center">
+        {renderParentLabel()}
+        {isCoarse && hasRealPath && (
+          <button
+            type="button"
+            aria-label={`Toggle ${item.label} submenu`}
+            aria-expanded={open}
+            className="px-2 py-1.5 text-[13px] text-text-secondary hover:text-accent bg-transparent border-none cursor-pointer"
+            onClick={() => setOpen((v) => !v)}
+          >
+            <span aria-hidden="true">{open ? '▾' : '▸'}</span>
+          </button>
+        )}
+      </span>
+      {open && children.length > 0 && (
+        <>
+          <div className="absolute top-full left-0 right-0 h-2" />
+          <div className="absolute top-[calc(100%+4px)] left-0 bg-bg-card border border-border rounded-xl p-1 min-w-[160px] shadow-lg z-[200]">
+            {children.map((child) => {
+              const href = crossOriginHref(child);
+              const childClass = `block px-3 py-2 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
+                isActivePath(location, child.path)
+                  ? 'bg-accent/10 text-accent'
+                  : 'text-text-secondary hover:bg-white/5 hover:text-accent'
+              }`;
+              if (href) {
+                return (
+                  <a
+                    key={href}
+                    href={href}
+                    className={childClass}
+                    onClick={() => setOpen(false)}
+                  >
+                    {child.label}
+                  </a>
+                );
+              }
+              return (
+                <Link
+                  key={child.path}
+                  to={child.path}
+                  className={childClass}
+                  onClick={() => setOpen(false)}
+                >
+                  {child.label}
+                </Link>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/shared-ui/src/components/AppHeader/index.ts
+++ b/packages/shared-ui/src/components/AppHeader/index.ts
@@ -5,6 +5,7 @@ export { BackendChip } from './BackendChip';
 export type { BackendStatus } from './BackendChip';
 export { HostPicker } from './HostPicker';
 export { MainNav } from './MainNav';
+export { NavDisclosure } from './NavDisclosure';
 export { ToolsDropdown } from './ToolsDropdown';
 export { useMenu, useBackendVersion } from './use-menu';
 export type { NavItem, NavSet, MenuApiItem, CrossOriginResolver } from './nav-types';

--- a/packages/shared-ui/src/components/AppHeader/nav-types.ts
+++ b/packages/shared-ui/src/components/AppHeader/nav-types.ts
@@ -5,11 +5,14 @@ export type NavItem = {
   label: string;
   studio?: string;
   query?: Record<string, string>;
+  children?: NavItem[];
 };
 
 export type NavSet = { main: NavItem[]; tools: NavItem[] };
 
 export type MenuApiItem = {
+  id?: string;
+  parentId?: string | null;
   path: string;
   label: string;
   group?: string;
@@ -28,15 +31,17 @@ export function isActivePath(location: Location, path: string): boolean {
   return location.pathname === path.split('?')[0];
 }
 
+type OrderedNavItem = NavItem & { order: number };
+
 export function buildNavSet(items: MenuApiItem[]): NavSet {
-  const main: Array<NavItem & { order: number }> = [];
-  const tools: Array<NavItem & { order: number }> = [];
+  const main: OrderedNavItem[] = [];
+  const tools: OrderedNavItem[] = [];
+  const byId = new Map<string, OrderedNavItem>();
+  const childrenByParent = new Map<string, OrderedNavItem[]>();
+
   for (const item of items) {
     if (!item || typeof item.path !== 'string' || typeof item.label !== 'string') continue;
-    const bucket =
-      item.group === 'tools' ? tools : item.group === 'main' ? main : null;
-    if (!bucket) continue;
-    const entry: NavItem & { order: number } = {
+    const entry: OrderedNavItem = {
       path: item.path,
       label: item.label,
       order: typeof item.order === 'number' ? item.order : 999,
@@ -49,17 +54,33 @@ export function buildNavSet(items: MenuApiItem[]): NavSet {
       }
       if (Object.keys(clean).length > 0) entry.query = clean;
     }
-    bucket.push(entry);
+
+    if (typeof item.id === 'string' && item.id) byId.set(item.id, entry);
+
+    if (typeof item.parentId === 'string' && item.parentId) {
+      const bucket = childrenByParent.get(item.parentId) ?? [];
+      bucket.push(entry);
+      childrenByParent.set(item.parentId, bucket);
+      continue;
+    }
+
+    const topBucket =
+      item.group === 'tools' ? tools : item.group === 'main' ? main : null;
+    if (!topBucket) continue;
+    topBucket.push(entry);
   }
-  const byOrder = (a: { order: number }, b: { order: number }) => a.order - b.order;
+
+  // Attach children to their parents (by id). Unresolved parents are dropped.
+  for (const [parentId, kids] of childrenByParent.entries()) {
+    const parent = byId.get(parentId);
+    if (!parent) continue;
+    kids.sort(byOrder);
+    parent.children = kids.map(strip);
+  }
+
   main.sort(byOrder);
   tools.sort(byOrder);
-  const strip = ({ path, label, studio, query }: NavItem & { order: number }): NavItem => {
-    const out: NavItem = { path, label };
-    if (studio) out.studio = studio;
-    if (query) out.query = query;
-    return out;
-  };
+
   const mainItems = main.map(strip);
   return {
     main: mainItems.some((n) => n.path === '/' && !n.studio)
@@ -67,4 +88,16 @@ export function buildNavSet(items: MenuApiItem[]): NavSet {
       : [{ path: '/', label: 'Overview' }, ...mainItems],
     tools: tools.map(strip),
   };
+}
+
+function byOrder(a: { order: number }, b: { order: number }) {
+  return a.order - b.order;
+}
+
+function strip(entry: OrderedNavItem): NavItem {
+  const out: NavItem = { path: entry.path, label: entry.label };
+  if (entry.studio) out.studio = entry.studio;
+  if (entry.query) out.query = entry.query;
+  if (entry.children) out.children = entry.children;
+  return out;
 }


### PR DESCRIPTION
## Summary
- Shared-ui AppHeader now renders nested submenus for any nav item with `children[]`
- `buildNavSet` groups flat API items by `parentId` → attaches them to the matching parent by `id`
- New `NavDisclosure` component: hover panel on desktop, tap-chevron on coarse-pointer / ≤640px
- Parent label itself still navigates (e.g. Canvas parent with `studio='canvas.*'` → canvas root); children deep-link via existing `defaultCrossOriginHref` — PR #21 query merge preserved
- Fallback `DEFAULT_NAV`: Canvas is now a top-level item with `Map` + `Planets` as children (moved off the Tools dropdown) so the nested render is exercised before backend #958 lands

## Test plan
- [x] `bun run build` (tsc -b + vite build) in apps/studio — passes
- [ ] Hover "Canvas ▸" in studio → panel shows Map, Planets
- [ ] Click "Canvas ▸" label → navigates to `canvas.buildwithoracle.com/?host=…`
- [ ] Click "Map" child → navigates to `canvas.buildwithoracle.com/?host=…&plugin=map`
- [ ] On ≤640px viewport, tap chevron → accordion opens; tap parent label → navigate
- [ ] Once backend #958 + #31 land: verify live `/api/menu` with `parentId` populates nested panels identically

Closes #28

🤖 ตอบโดย arra-oracle-v3 จาก Nat → arra-oracle-v3-oracle