### PR TITLE
feat(studio): #30 query editor cell on menu rows

### DIFF
--- a/apps/studio/src/components/menu/QueryCell.tsx
+++ b/apps/studio/src/components/menu/QueryCell.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+
+type QueryMap = Record<string, string>;
+
+interface Props {
+  value: QueryMap | null | undefined;
+  onSave: (next: QueryMap | null) => void;
+}
+
+function entriesOf(v: QueryMap | null | undefined): Array<[string, string]> {
+  if (!v) return [];
+  return Object.entries(v);
+}
+
+export function QueryCell({ value, onSave }: Props) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState<Array<[string, string]>>(() => entriesOf(value));
+
+  function expand() {
+    setDraft(entriesOf(value));
+    setOpen(true);
+  }
+
+  function commit() {
+    const cleaned: QueryMap = {};
+    for (const [k, v] of draft) {
+      const key = k.trim();
+      if (key) cleaned[key] = v;
+    }
+    const next = Object.keys(cleaned).length === 0 ? null : cleaned;
+    onSave(next);
+    setOpen(false);
+  }
+
+  const count = value ? Object.keys(value).length : 0;
+  const summary = count === 0
+    ? 'none'
+    : Object.entries(value!).map(([k, v]) => `${k}=${v}`).join(' ');
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={expand}
+        className="text-[10px] font-mono px-2 py-0.5 rounded bg-teal-500/10 text-teal-300 border border-teal-500/30 hover:bg-teal-500/20 max-w-[140px] truncate"
+        title={`query: ${summary}`}
+      >
+        {count === 0 ? '{ }' : `{${count}}`}
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1 p-2 rounded border border-teal-500/40 bg-bg-base max-w-[280px]">
+      <div className="text-[10px] text-text-secondary">query</div>
+      {draft.length === 0 && (
+        <div className="text-[10px] text-text-secondary italic">no entries</div>
+      )}
+      {draft.map(([k, v], idx) => (
+        <div key={idx} className="flex gap-1">
+          <input
+            type="text"
+            value={k}
+            placeholder="key"
+            onChange={(e) => setDraft((d) => d.map((row, i) => i === idx ? [e.target.value, row[1]] : row))}
+            className="flex-1 min-w-0 bg-bg-elevated border border-border rounded px-1 py-0.5 text-[11px] font-mono"
+          />
+          <input
+            type="text"
+            value={v}
+            placeholder="value"
+            onChange={(e) => setDraft((d) => d.map((row, i) => i === idx ? [row[0], e.target.value] : row))}
+            className="flex-1 min-w-0 bg-bg-elevated border border-border rounded px-1 py-0.5 text-[11px] font-mono"
+          />
+          <button
+            type="button"
+            onClick={() => setDraft((d) => d.filter((_, i) => i !== idx))}
+            className="text-text-secondary hover:text-red-400 text-xs px-1"
+            title="Remove"
+          >×</button>
+        </div>
+      ))}
+      <div className="flex gap-1 justify-between pt-1">
+        <button
+          type="button"
+          onClick={() => setDraft((d) => [...d, ['', '']])}
+          className="text-[10px] text-accent hover:underline"
+        >+ add</button>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="text-[10px] text-text-secondary hover:text-accent"
+          >cancel</button>
+          <button
+            type="button"
+            onClick={commit}
+            className="text-[10px] text-teal-300 hover:text-teal-200"
+          >save</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/src/components/menu/SortableRow.tsx
+++ b/apps/studio/src/components/menu/SortableRow.tsx
@@ -14,6 +14,7 @@ export interface MenuItem {
   icon: string | null;
   touchedAt: number | null;
   host?: string | null;
+  query?: Record<string, string> | null;
 }
 
 export const GROUPS = ['main', 'tools', 'admin', 'hidden'] as const;

--- a/apps/studio/src/components/menu/TreeRow.tsx
+++ b/apps/studio/src/components/menu/TreeRow.tsx
@@ -2,6 +2,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { MenuItem } from './SortableRow';
 import { GROUP_COLORS } from './SortableRow';
+import { QueryCell } from './QueryCell';
 
 const SOURCE_COLORS: Record<string, string> = {
   route: 'bg-blue-500/10 text-blue-300',
@@ -71,6 +72,10 @@ export function TreeRow({ item, depth, hasChildren, parentOptions, onPatch, onEd
         ))}
       </select>
       <span className={`px-2 py-0.5 rounded text-[10px] ${SOURCE_COLORS[item.source] ?? ''}`}>{item.source}</span>
+      <QueryCell
+        value={item.query ?? null}
+        onSave={(next) => onPatch(item.id, { query: next })}
+      />
       {host && (
         <span className="px-2 py-0.5 rounded text-[10px] bg-indigo-500/10 text-indigo-300 border border-indigo-500/30 font-mono" title="Host filter">
           {host}


### PR DESCRIPTION
## Summary
- Adds collapsible key/value editor for each row's `query` field
- Collapsed: `{N}` chip showing entry count, full query in tooltip
- Expanded: inline table of key/value inputs, add/remove rows, save/cancel
- Empty object on save → `null` (field dropped)
- Wires to existing `onPatch(id, { query })` pipeline

## Depends on
- arra-oracle-v3#959 (backend query JSON column — commit 3fe54d0)
- Stacked on #32 (parent picker). Base = `feat/30-studio-menu-editor`. Retarget to `main` once #32 merges.

## Test plan
- [ ] Open Map row, expand query cell, add `plugin=map`, save → collapsed chip shows `{1}`
- [ ] Refresh → value persists
- [ ] Remove all entries, save → chip shows `{ }`, server value is `null`
- [ ] Reparent via picker still works (regression check on #32)

Closes remaining half of #30.

🤖 ตอบโดย arra-oracle-v3 จาก Nat → arra-oracle-v3-oracle

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>