### PR TITLE
fix: unify feed + canvas headers with AppHeader (#36)

### DIFF
--- a/apps/canvas/src/components/Header.tsx
+++ b/apps/canvas/src/components/Header.tsx
@@ -1,37 +1,6 @@
-import { BackendChip, Brand, VersionChip } from '@ui-oracle/shared-ui';
+import { AppHeader } from '@ui-oracle/shared-ui';
 import { ping } from '../api/oracle';
 
-const STUDIO_ORIGIN = 'https://studio.buildwithoracle.com';
-
-/**
- * Canvas bundle header — intentionally minimal. Just brand + back-to-studio
- * link + backend status chip, no nav.
- */
 export function Header() {
-  return (
-    <header
-      className="sticky top-0 z-50 backdrop-blur-xl"
-      style={{
-        background: 'rgba(10, 10, 15, 0.7)',
-        borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
-      }}
-    >
-      <div className="flex justify-between items-center gap-4 px-4 py-2 max-w-[1400px] mx-auto">
-        <Brand label="ARRA 🔮Racle — Canvas">
-          <VersionChip />
-        </Brand>
-
-        <div className="flex items-center gap-2 text-xs font-mono shrink-0">
-          <a
-            href={STUDIO_ORIGIN}
-            className="px-2 py-0.5 rounded-md border border-border text-text-muted hover:bg-bg-card transition-all duration-150"
-            title="Back to studio.buildwithoracle.com"
-          >
-            ← studio
-          </a>
-          <BackendChip ping={ping} />
-        </div>
-      </div>
-    </header>
-  );
+  return <AppHeader brandLabel="ARRA 🔮Racle — Canvas" ping={ping} />;
 }

--- a/apps/feed/src/components/Header.tsx
+++ b/apps/feed/src/components/Header.tsx
@@ -1,33 +1,6 @@
-import { BackendChip, Brand, VersionChip } from '@ui-oracle/shared-ui';
+import { AppHeader } from '@ui-oracle/shared-ui';
 import { ping } from '../api/oracle';
 
-const STUDIO_ORIGIN = 'https://studio.buildwithoracle.com';
-
 export function Header() {
-  return (
-    <header
-      className="sticky top-0 z-50 backdrop-blur-xl"
-      style={{
-        background: 'rgba(10, 10, 15, 0.7)',
-        borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
-      }}
-    >
-      <div className="flex justify-between items-center gap-4 px-4 py-2 max-w-[1400px] mx-auto">
-        <Brand label="ARRA 🔮Racle — Feed">
-          <VersionChip />
-        </Brand>
-
-        <div className="flex items-center gap-2 text-xs font-mono shrink-0">
-          <a
-            href={STUDIO_ORIGIN}
-            className="px-2 py-0.5 rounded-md border border-border text-text-muted hover:bg-bg-card transition-all duration-150"
-            title="Back to studio.buildwithoracle.com"
-          >
-            ← studio
-          </a>
-          <BackendChip ping={ping} />
-        </div>
-      </div>
-    </header>
-  );
+  return <AppHeader brandLabel="ARRA 🔮Racle — Feed" ping={ping} />;
 }


### PR DESCRIPTION
## Summary

Feed + canvas were using custom minimal "← studio" headers — no nav bar at all. Every subdomain must render the same AppHeader so users can navigate seamlessly across studio/feed/schedule/canvas/vector.

Matches the pattern already used by \`apps/schedule/src/components/Header.tsx\`.

Closes #36.

## Diff

- 2 files, 4 insertions, 62 deletions (pure simplification)

## Test

- [x] tsc passes (build deferred until deploy step)
- [ ] Post-merge: deploy feed + canvas, verify visual parity with schedule/vector headers

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle