### PR TITLE
fix(shared-ui): lean DEFAULT_NAV to 4 top-level + Canvas/Tools submenus

### DIFF
--- a/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
@@ -12,14 +12,8 @@ import type { CrossOriginResolver, NavItem, NavSet } from './nav-types';
 const DEFAULT_NAV: NavSet = {
   main: [
     { path: '/', label: 'Overview' },
-    { path: '/feed', label: 'Feed' },
-    { path: '/map', label: 'Memory' },
-    { path: '/search', label: 'Search' },
-    { path: '/forum', label: 'Forum' },
-    { path: '/pulse', label: 'Pulse' },
-    { path: '/sessions', label: 'Sessions' },
-    { path: '/plugins', label: 'Plugins' },
-    { path: '/activity?tab=searches', label: 'Activity' },
+    { path: '/feed', label: 'Feed', studio: 'feed.buildwithoracle.com' },
+    { path: '/schedule', label: 'Schedule', studio: 'schedule.buildwithoracle.com' },
     {
       path: '/',
       label: 'Canvas',
@@ -41,11 +35,17 @@ const DEFAULT_NAV: NavSet = {
     },
   ],
   tools: [
+    { path: '/search', label: 'Search' },
+    { path: '/forum', label: 'Forum' },
+    { path: '/map', label: 'Memory' },
+    { path: '/pulse', label: 'Pulse' },
+    { path: '/sessions', label: 'Sessions' },
+    { path: '/plugins', label: 'Plugins' },
+    { path: '/activity?tab=searches', label: 'Activity' },
     { path: '/playground', label: 'Playground' },
     { path: '/compare', label: 'Compare' },
     { path: '/evolution', label: 'Evolution' },
     { path: '/traces', label: 'Traces' },
-    { path: '/schedule', label: 'Schedule' },
   ],
 };
 


### PR DESCRIPTION
## Summary

Reduces DEFAULT_NAV top-level from 10 → 4 items, moves overflow into Tools dropdown (already existed) and Canvas submenu.

## Research

UX consensus for primary nav: 4-6 top-level items with disclosure submenus for the rest. Nielsen Norman / Miller 7±2 caps at 9; Stripe/Vercel/GitHub ship 4.

## Layout

- **main (4)**: Overview · Feed (→feed.*) · Schedule (→schedule.*) · Canvas ▸ (→canvas.*)
  - Canvas children: Map · Planets (deep-link via query={plugin})
- **tools (11)**: Search · Forum · Memory · Pulse · Sessions · Plugins · Activity · Playground · Compare · Evolution · Traces

Feed + Schedule now cross-origin to their subdomains (matches #951 pattern — single source of truth).

## Test plan

- [x] Deploy on all 5 subdomains (studio, feed, schedule, canvas, vector)
- [x] Visual verify via dev-browser screenshot grid — all identical

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle