### PR TITLE
fix(shared-ui): host-aware active nav state + submenu polish

### DIFF
--- a/packages/shared-ui/src/components/AppHeader/MainNav.tsx
+++ b/packages/shared-ui/src/components/AppHeader/MainNav.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from 'react-router-dom';
 import type { CrossOriginResolver, NavItem } from './nav-types';
-import { isActivePath } from './nav-types';
+import { isActiveNav } from './nav-types';
 import { NavDisclosure } from './NavDisclosure';
 
 interface MainNavProps {
@@ -29,27 +29,21 @@ export function MainNav({ items, crossOriginHref }: MainNavProps) {
           );
         }
         const href = crossOriginHref(item);
+        const active = isActiveNav(location, item);
+        const cls = `px-2.5 py-1.5 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
+          active
+            ? 'bg-accent/15 text-accent font-semibold border border-accent/20'
+            : 'text-text-secondary hover:bg-bg-card hover:text-accent border border-transparent'
+        }`;
         if (href) {
           return (
-            <a
-              key={href}
-              href={href}
-              className="px-2.5 py-1.5 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 text-text-secondary hover:bg-bg-card hover:text-accent border border-transparent"
-            >
+            <a key={href} href={href} className={cls}>
               {item.label}
             </a>
           );
         }
         return (
-          <Link
-            key={item.path}
-            to={item.path}
-            className={`px-2.5 py-1.5 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
-              isActivePath(location, item.path)
-                ? 'bg-accent/15 text-accent font-semibold border border-accent/20'
-                : 'text-text-secondary hover:bg-bg-card hover:text-accent border border-transparent'
-            }`}
-          >
+          <Link key={item.path} to={item.path} className={cls}>
             {item.label}
           </Link>
         );

--- a/packages/shared-ui/src/components/AppHeader/NavDisclosure.tsx
+++ b/packages/shared-ui/src/components/AppHeader/NavDisclosure.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import type { CrossOriginResolver, NavItem } from './nav-types';
-import { isActivePath } from './nav-types';
+import { isActiveNav } from './nav-types';
 
 interface NavDisclosureProps {
   item: NavItem;
@@ -31,8 +31,8 @@ export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
   const children = item.children ?? [];
   const parentHref = crossOriginHref(item);
   const hasRealPath = item.path && item.path !== '#';
-  const anyActive = isActivePath(location, item.path)
-    || children.some((c) => isActivePath(location, c.path));
+  const anyActive = isActiveNav(location, item)
+    || children.some((c) => isActiveNav(location, c));
 
   const labelClass = `px-2.5 py-1.5 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
     anyActive
@@ -89,12 +89,12 @@ export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
       {open && children.length > 0 && (
         <>
           <div className="absolute top-full left-0 right-0 h-2" />
-          <div className="absolute top-[calc(100%+4px)] left-0 bg-bg-card border border-border rounded-xl p-1 min-w-[160px] shadow-lg z-[200]">
+          <div className="absolute top-[calc(100%+4px)] left-0 bg-bg-card/95 backdrop-blur-xl border border-border rounded-xl p-1 min-w-[180px] z-[200]" style={{boxShadow: '0 10px 40px -10px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.04)'}}>
             {children.map((child) => {
               const href = crossOriginHref(child);
               const childClass = `block px-3 py-2 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
-                isActivePath(location, child.path)
-                  ? 'bg-accent/10 text-accent'
+                isActiveNav(location, child)
+                  ? 'bg-accent/15 text-accent font-semibold'
                   : 'text-text-secondary hover:bg-white/5 hover:text-accent'
               }`;
               if (href) {

--- a/packages/shared-ui/src/components/AppHeader/nav-types.ts
+++ b/packages/shared-ui/src/components/AppHeader/nav-types.ts
@@ -31,6 +31,23 @@ export function isActivePath(location: Location, path: string): boolean {
   return location.pathname === path.split('?')[0];
 }
 
+/**
+ * Host-aware active check. If the item carries a `studio` subdomain, it's
+ * active only when the current window host matches that subdomain (ignoring
+ * path). For local items, falls back to pathname match.
+ */
+export function isActiveNav(
+  location: Location,
+  item: { path: string; studio?: string },
+): boolean {
+  if (item.studio && typeof window !== 'undefined') {
+    return window.location.hostname === item.studio
+      || window.location.hostname.endsWith('.' + item.studio);
+  }
+  if (item.studio) return false;
+  return isActivePath(location, item.path);
+}
+
 type OrderedNavItem = NavItem & { order: number };
 
 export function buildNavSet(items: MenuApiItem[]): NavSet {


### PR DESCRIPTION
## Summary

Active nav highlighting was wrong on all subdomains:
- Canvas ▸ always highlighted on every subdomain (parent path='/' matched pathname='/')
- Cross-origin links (Feed on feed.*, Schedule on schedule.*) never highlighted
- Overview highlighted on studio but not on subdomains with same pathname

Fix: \`isActiveNav\` — when item has \`studio\` field, match on current \`window.location.hostname\`. Falls back to pathname for local items.

Also: submenu panel gets backdrop-blur, deeper shadow, ring highlight, +20px min-width.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle