### PR TITLE
fix(shared-ui): scope Overview active state to studio

### DIFF
--- a/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
@@ -11,7 +11,7 @@ import type { CrossOriginResolver, NavItem, NavSet } from './nav-types';
 
 const DEFAULT_NAV: NavSet = {
   main: [
-    { path: '/', label: 'Overview' },
+    { path: '/', label: 'Overview', studio: 'studio.buildwithoracle.com' },
     { path: '/feed', label: 'Feed', studio: 'feed.buildwithoracle.com' },
     { path: '/schedule', label: 'Schedule', studio: 'schedule.buildwithoracle.com' },
     {


### PR DESCRIPTION
Overview was highlighted on every subdomain because path='/' matched pathname='/'. Now carries studio='studio.buildwithoracle.com' so active only when on studio.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle