### PR TITLE
a11y: aria-current="page" on active nav items

### DIFF
--- a/packages/shared-ui/src/components/AppHeader/MainNav.tsx
+++ b/packages/shared-ui/src/components/AppHeader/MainNav.tsx
@@ -37,13 +37,13 @@ export function MainNav({ items, crossOriginHref }: MainNavProps) {
         }`;
         if (href) {
           return (
-            <a key={href} href={href} className={cls}>
+            <a key={href} href={href} className={cls} aria-current={active ? 'page' : undefined}>
               {item.label}
             </a>
           );
         }
         return (
-          <Link key={item.path} to={item.path} className={cls}>
+          <Link key={item.path} to={item.path} className={cls} aria-current={active ? 'page' : undefined}>
             {item.label}
           </Link>
         );

--- a/packages/shared-ui/src/components/AppHeader/NavDisclosure.tsx
+++ b/packages/shared-ui/src/components/AppHeader/NavDisclosure.tsx
@@ -31,7 +31,8 @@ export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
   const children = item.children ?? [];
   const parentHref = crossOriginHref(item);
   const hasRealPath = item.path && item.path !== '#';
-  const anyActive = isActiveNav(location, item)
+  const parentActive = isActiveNav(location, item);
+  const anyActive = parentActive
     || children.some((c) => isActiveNav(location, c));
 
   const labelClass = `px-2.5 py-1.5 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
@@ -54,13 +55,13 @@ export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
     }
     if (parentHref) {
       return (
-        <a href={parentHref} className={labelClass}>
+        <a href={parentHref} className={labelClass} aria-current={parentActive ? 'page' : undefined}>
           {item.label} <span aria-hidden="true">▸</span>
         </a>
       );
     }
     return (
-      <Link to={item.path} className={labelClass}>
+      <Link to={item.path} className={labelClass} aria-current={parentActive ? 'page' : undefined}>
         {item.label} <span aria-hidden="true">▸</span>
       </Link>
     );
@@ -100,8 +101,9 @@ export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
           >
             {children.map((child) => {
               const href = crossOriginHref(child);
+              const childActive = isActiveNav(location, child);
               const childClass = `block px-3 py-2 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
-                isActiveNav(location, child)
+                childActive
                   ? 'bg-accent/15 text-accent font-semibold'
                   : 'text-text-secondary hover:bg-white/5 hover:text-accent'
               }`;
@@ -113,6 +115,7 @@ export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
                     className={childClass}
                     onClick={() => setOpen(false)}
                     role="menuitem"
+                    aria-current={childActive ? 'page' : undefined}
                   >
                     {child.label}
                   </a>
@@ -125,6 +128,7 @@ export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
                   className={childClass}
                   onClick={() => setOpen(false)}
                   role="menuitem"
+                  aria-current={childActive ? 'page' : undefined}
                 >
                   {child.label}
                 </Link>

--- a/packages/shared-ui/src/components/AppHeader/ToolsDropdown.tsx
+++ b/packages/shared-ui/src/components/AppHeader/ToolsDropdown.tsx
@@ -55,13 +55,13 @@ export function ToolsDropdown({ items, crossOriginHref, label = 'Tools ▾' }: T
           }`;
           if (href) {
             return (
-              <a key={href} href={href} className={cls} onClick={() => setOpen(false)} role="menuitem">
+              <a key={href} href={href} className={cls} onClick={() => setOpen(false)} role="menuitem" aria-current={active ? 'page' : undefined}>
                 {item.label}
               </a>
             );
           }
           return (
-            <Link key={item.path} to={item.path} className={cls} onClick={() => setOpen(false)} role="menuitem">
+            <Link key={item.path} to={item.path} className={cls} onClick={() => setOpen(false)} role="menuitem" aria-current={active ? 'page' : undefined}>
               {item.label}
             </Link>
           );


### PR DESCRIPTION
## Summary

- `MainNav.tsx`: emit `aria-current="page"` on active leaf `<a>` / `<Link>`.
- `NavDisclosure.tsx`: parent label gets `aria-current` only when the parent itself matches (not on child match); children get it when active.
- `ToolsDropdown.tsx`: items emit `aria-current` when active.

Inactive items omit the attribute (`undefined`). The Tools button itself stays without `aria-current` — only exact menu items get it.

PR 2 of the menu active-state fix wave (plan: `ψ/plans/2026-04-20_menu-active-state-fix.md`).

## Test plan

- [ ] Visit each nav route and inspect DOM for `aria-current="page"` on the matching item only
- [ ] Confirm parent disclosure label has no `aria-current` when only a child matches (e.g. `studio.*/canvas?plugin=galaxy`)
- [ ] Screen-reader announces "current page" on the active nav item

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle