### PR TITLE
fix(shared-ui): isActiveNav runs path gate unconditionally

### DIFF
--- a/packages/shared-ui/src/components/AppHeader/nav-types.ts
+++ b/packages/shared-ui/src/components/AppHeader/nav-types.ts
@@ -31,28 +31,33 @@ export function isActivePath(location: Location, path: string): boolean {
   return location.pathname === path.split('?')[0];
 }
 
-// Host- and query-aware active check. studio-scoped item active when current
-// hostname matches; if item also has query, every key/value must match
-// window.location.search (Canvas plugin deep-link highlighting). Local items
-// fall back to pathname match.
+// Three-gate active check: host (if studio-scoped), path (always), query (if set).
+// studio is a HOST GATE — it scopes *where* the item can be active, not *whether*
+// the path matters. Previously, a matching host short-circuited to `true` and
+// caused every studio-scoped item to light up on the same origin regardless of
+// pathname (Overview + Search both active on studio.*/ etc.).
 export function isActiveNav(
   location: Location,
   item: { path: string; studio?: string; query?: Record<string, string> },
 ): boolean {
-  if (item.studio && typeof window !== 'undefined') {
+  if (item.studio) {
+    if (typeof window === 'undefined') return false;
     const hostMatch = window.location.hostname === item.studio
       || window.location.hostname.endsWith('.' + item.studio);
     if (!hostMatch) return false;
-    if (item.query) {
-      const params = new URLSearchParams(window.location.search);
-      for (const [k, v] of Object.entries(item.query)) {
-        if (params.get(k) !== v) return false;
-      }
-    }
-    return true;
   }
-  if (item.studio) return false;
-  return isActivePath(location, item.path);
+
+  const itemPath = item.path.split('?')[0];
+  if (location.pathname !== itemPath) return false;
+
+  if (item.query) {
+    if (typeof window === 'undefined') return false;
+    const params = new URLSearchParams(window.location.search);
+    for (const [k, v] of Object.entries(item.query)) {
+      if (params.get(k) !== v) return false;
+    }
+  }
+  return true;
 }
 
 type OrderedNavItem = NavItem & { order: number };


### PR DESCRIPTION
## Summary

`isActiveNav` treated `item.studio` as a **path replacement** instead of a host gate: when the current hostname matched `item.studio`, it short-circuited to `true`, so every studio-scoped item lit up on the same origin regardless of pathname.

Symptoms on production:
- `studio.buildwithoracle.com/` → Overview **and** Search both active
- `studio.buildwithoracle.com/map` → Overview + Memory + others
- `canvas.buildwithoracle.com/?plugin=galaxy` → galaxy not highlighted (parent-gate swallowed the query check)

Fixes by re-casting the function as three sequential gates:

1. **Host gate** — if `item.studio` is set, `window.location.hostname` must equal or subdomain-match
2. **Path gate** (always) — `location.pathname` must equal `item.path` (sans query)
3. **Query gate** — if `item.query` is set, every key/value must match URL search params

## Expected test matrix

| URL | Expected active |
|---|---|
| `studio.*/` | Overview only |
| `studio.*/search` | Search only |
| `studio.*/map` | Memory only |
| `canvas.*/` | Canvas only |
| `canvas.*/?plugin=galaxy` | Canvas + Galaxy (parent by host, child by query) |
| `feed.*/` | Feed only |
| `schedule.*/` | Schedule only (in Tools) |
| `vector.*/` | Vector Playground only |

## Scope

- One file: `packages/shared-ui/src/components/AppHeader/nav-types.ts`
- +18/-13 lines
- No API change — same function signature, same callers
- No app-level changes required

Plan reference: `ψ/plans/2026-04-20_menu-active-state-fix.md` PR 1

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle