### PR TITLE
fix(shared-ui): unify crossOriginHref resolver — preserve path + query

### DIFF
--- a/apps/studio/src/components/Header.tsx
+++ b/apps/studio/src/components/Header.tsx
@@ -1,32 +1,8 @@
 import { Link } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { AppHeader, hostLabel, isStudioHost, type CrossOriginResolver, type NavItem } from '@ui-oracle/shared-ui';
+import { AppHeader } from '@ui-oracle/shared-ui';
 import { useAuth } from '../contexts/AuthContext';
 import { API_BASE, ping } from '../api/oracle';
-
-const VECTOR_ORIGIN = 'https://vector.buildwithoracle.com';
-
-/** Studio bundle navigates cross-origin to vector.* for playground/compare paths. */
-function isVectorPath(path: string): boolean {
-  const clean = path.split('?')[0];
-  return (
-    clean === '/playground' ||
-    clean.startsWith('/playground/') ||
-    clean === '/compare' ||
-    clean.startsWith('/compare/')
-  );
-}
-
-const studioCrossOriginHref: CrossOriginResolver = (item: NavItem) => {
-  const currentHost = hostLabel().replace(' (default)', '');
-  if (item.studio) {
-    return `https://${item.studio}${item.path}?host=${encodeURIComponent(currentHost)}`;
-  }
-  if (isStudioHost() && isVectorPath(item.path)) {
-    return `${VECTOR_ORIGIN}${item.path}?host=${encodeURIComponent(currentHost)}`;
-  }
-  return null;
-};
 
 /** Studio-specific extras: session duration, search/learning counters, settings link, logout. */
 function StudioExtras() {
@@ -95,13 +71,14 @@ function StudioExtras() {
 
 /**
  * Studio bundle header — composes the shared AppHeader with studio-specific
- * extras (session stats, settings, auth logout) and studio-to-vector cross-origin rules.
+ * extras (session stats, settings, auth logout). Cross-origin routing
+ * (including the studio→vector bounce for playground/compare) lives in the
+ * unified resolver in shared-ui.
  */
 export function Header() {
   return (
     <AppHeader
       ping={ping}
-      crossOriginHref={studioCrossOriginHref}
       topRowExtras={<StudioExtras />}
     />
   );

--- a/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
@@ -32,6 +32,7 @@ const DEFAULT_NAV: NavSet = {
 };
 
 const STUDIO_ORIGIN = 'https://studio.buildwithoracle.com';
+const VECTOR_ORIGIN = 'https://vector.buildwithoracle.com';
 
 function appendQuery(base: string, query: Record<string, string> | undefined): string {
   if (!query) return base;
@@ -42,6 +43,23 @@ function appendQuery(base: string, query: Record<string, string> | undefined): s
     .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
     .join('&');
   return `${base}${sep}${qs}`;
+}
+
+// Studio → vector for the playground/compare paths. Kept as a small helper so
+// app overrides can reuse the same detection logic.
+export function isVectorPath(path: string): boolean {
+  const clean = path.split('?')[0];
+  return (
+    clean === '/playground' ||
+    clean.startsWith('/playground/') ||
+    clean === '/compare' ||
+    clean.startsWith('/compare/')
+  );
+}
+
+function buildHref(origin: string, item: NavItem, currentHost: string): string {
+  const withHost = appendQuery(`${origin}${item.path}`, { host: currentHost });
+  return appendQuery(withHost, item.query);
 }
 
 interface AppHeaderProps {
@@ -59,28 +77,37 @@ interface AppHeaderProps {
   hideToolsDropdown?: boolean;
 }
 
+// Unified cross-origin resolver — preserves BOTH `item.path` and `item.query`
+// on every bounce. Previously the studio and shared-ui variants disagreed
+// (one dropped query, the other forced '/'), so an item with both path and
+// query (e.g. Canvas plugin=galaxy at /) lost data in one direction or the
+// other. Every branch here routes through `buildHref`, which adds ?host=
+// first and then merges `item.query`.
 function defaultCrossOriginHref(item: NavItem): string | null {
   const currentHost = hostLabel().replace(' (default)', '');
+
   if (item.studio) {
-    // `studio` field means "separate app on its own subdomain" — land at
-    // root of that subdomain. `query` merges additional params for deep-links
-    // (e.g. canvas plugin=map).
-    const base = `https://${item.studio}/?host=${encodeURIComponent(currentHost)}`;
-    return appendQuery(base, item.query);
+    if (typeof window !== 'undefined' && window.location.hostname === item.studio) {
+      return null;
+    }
+    return buildHref(`https://${item.studio}`, item, currentHost);
   }
+
+  if (isStudioHost() && isVectorPath(item.path)) {
+    return buildHref(VECTOR_ORIGIN, item, currentHost);
+  }
+
   if (isVectorHost()) {
     const clean = item.path.split('?')[0];
     const isPlayground = clean === '/' || clean === '/playground';
-    if (!isPlayground) {
-      return `${STUDIO_ORIGIN}${item.path}?host=${encodeURIComponent(currentHost)}`;
-    }
-    return null;
+    if (isPlayground) return null;
+    return buildHref(STUDIO_ORIGIN, item, currentHost);
   }
-  // Any other non-studio subdomain (canvas, feed, schedule, …): local items
-  // don't exist here — bounce them to studio.
+
   if (!isStudioHost()) {
-    return `${STUDIO_ORIGIN}${item.path}?host=${encodeURIComponent(currentHost)}`;
+    return buildHref(STUDIO_ORIGIN, item, currentHost);
   }
+
   return null;
 }
 

--- a/packages/shared-ui/src/components/AppHeader/index.ts
+++ b/packages/shared-ui/src/components/AppHeader/index.ts
@@ -1,4 +1,4 @@
-export { AppHeader, defaultCrossOriginHref } from './AppHeader';
+export { AppHeader, defaultCrossOriginHref, isVectorPath } from './AppHeader';
 export { Brand } from './Brand';
 export { VersionChip } from './VersionChip';
 export { BackendChip } from './BackendChip';

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -4,6 +4,7 @@
 export {
   AppHeader,
   defaultCrossOriginHref,
+  isVectorPath,
   Brand,
   VersionChip,
   BackendChip,


### PR DESCRIPTION
## Summary

Studio's `studioCrossOriginHref` and shared-ui's `defaultCrossOriginHref` disagreed — studio preserved `item.path` but dropped `item.query`, while the default preserved query but forced `/` (dropping path). A nav item with both (e.g. `Canvas plugin=galaxy` at `/`) lost data in one direction or the other.

- Unified into a single resolver in `shared-ui/AppHeader.tsx`. Every bounce goes through a `buildHref` helper that appends `?host=` first and then merges `item.query` — both the path and the query survive.
- The studio→vector bounce for `/playground` and `/compare` now lives in the default resolver (`isVectorPath` is exported so apps can reuse it if they want to override).
- `studioCrossOriginHref` is deleted from `apps/studio/src/components/Header.tsx`; studio now uses the default.

## Test plan

- [x] `tsc -b` passes for `studio`, `vector`, `canvas`, `feed`, `schedule`
- [x] Mental trace: from `feed.*`, Canvas `{path:'/', query:{plugin:'galaxy'}, studio:'canvas.*'}` → `https://canvas.*/?host=feed.*&plugin=galaxy`
- [x] Mental trace: from `vector.*`, Memory `{path:'/map'}` → `https://studio.*/map?host=vector.*`
- [x] Mental trace: from `studio.*`, Compare `{path:'/compare'}` → `https://vector.*/compare?host=studio.*`
- [ ] Browser smoke test on deployed subdomains (follow-up, needs live deploy)

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle