### PR TITLE
fix(shared-ui): cross-origin nav lands at remote root

### DIFF
--- a/apps/vector/src/components/Header.tsx
+++ b/apps/vector/src/components/Header.tsx
@@ -6,7 +6,7 @@ import { ping } from '../api/oracle';
  * App-specific wiring: passes the local `ping` fn for the backend chip.
  */
 export function Header() {
-  return <AppHeader ping={ping} />;
+  return <AppHeader brandLabel="ARRA 🔮Racle — Vector" ping={ping} />;
 }
 
 /** Re-exported for existing imports (VectorSubNav etc.). */

--- a/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
@@ -13,7 +13,7 @@ const DEFAULT_NAV: NavSet = {
   main: [
     { path: '/', label: 'Overview', studio: 'studio.buildwithoracle.com' },
     { path: '/search', label: 'Search', studio: 'studio.buildwithoracle.com' },
-    { path: '/feed', label: 'Feed', studio: 'feed.buildwithoracle.com' },
+    { path: '/', label: 'Feed', studio: 'feed.buildwithoracle.com' },
     { path: '/map', label: 'Memory' },
     { path: '/forum', label: 'Forum' },
     { path: '/activity?tab=searches', label: 'Activity' },
@@ -21,7 +21,7 @@ const DEFAULT_NAV: NavSet = {
     { path: '/', label: 'Canvas', studio: 'canvas.buildwithoracle.com' },
   ],
   tools: [
-    { path: '/schedule', label: 'Schedule', studio: 'schedule.buildwithoracle.com' },
+    { path: '/', label: 'Schedule', studio: 'schedule.buildwithoracle.com' },
     { path: '/pulse', label: 'Pulse' },
     { path: '/sessions', label: 'Sessions' },
     { path: '/plugins', label: 'Plugins' },


### PR DESCRIPTION
After #54 preserved path across origins, clicking Feed from studio landed at feed.*/feed (SPA fallback) instead of feed.*/ root. DEFAULT_NAV fix: Feed + Schedule path '/' (these items mean 'visit that subdomain root'). Also vector brandLabel '— Vector' added.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle