### PR TITLE
feat(shared-ui): 5 main items with Memory + Canvas submenus

### DIFF
--- a/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
@@ -13,12 +13,33 @@ const DEFAULT_NAV: NavSet = {
   main: [
     { path: '/', label: 'Overview', studio: 'studio.buildwithoracle.com' },
     { path: '/search', label: 'Search', studio: 'studio.buildwithoracle.com' },
+    {
+      path: '#',
+      label: 'Memory',
+      children: [
+        { path: '/map', label: 'Map' },
+        { path: '/forum', label: 'Forum' },
+        { path: '/activity?tab=searches', label: 'Activity' },
+        { path: '/traces', label: 'Traces' },
+      ],
+    },
+    {
+      path: '/',
+      label: 'Canvas',
+      studio: 'canvas.buildwithoracle.com',
+      children: [
+        { path: '/', label: 'Map', studio: 'canvas.buildwithoracle.com', query: { plugin: 'map' } },
+        { path: '/', label: 'Planets', studio: 'canvas.buildwithoracle.com', query: { plugin: 'planets' } },
+        { path: '/', label: 'Wave', studio: 'canvas.buildwithoracle.com', query: { plugin: 'wave' } },
+        { path: '/', label: 'Cube', studio: 'canvas.buildwithoracle.com', query: { plugin: 'cube' } },
+        { path: '/', label: 'Torus', studio: 'canvas.buildwithoracle.com', query: { plugin: 'torus' } },
+        { path: '/', label: 'Galaxy', studio: 'canvas.buildwithoracle.com', query: { plugin: 'galaxy' } },
+        { path: '/', label: 'Solar', studio: 'canvas.buildwithoracle.com', query: { plugin: 'solar' } },
+        { path: '/', label: 'Graph 3D', studio: 'canvas.buildwithoracle.com', query: { plugin: 'graph3d' } },
+        { path: '/', label: 'Map 3D', studio: 'canvas.buildwithoracle.com', query: { plugin: 'map3d' } },
+      ],
+    },
     { path: '/', label: 'Feed', studio: 'feed.buildwithoracle.com' },
-    { path: '/map', label: 'Memory' },
-    { path: '/forum', label: 'Forum' },
-    { path: '/activity?tab=searches', label: 'Activity' },
-    { path: '/traces', label: 'Traces' },
-    { path: '/', label: 'Canvas', studio: 'canvas.buildwithoracle.com' },
   ],
   tools: [
     { path: '/', label: 'Schedule', studio: 'schedule.buildwithoracle.com' },


### PR DESCRIPTION
Consolidates 8 main → 5 + submenus. Canvas submenu restored (was dropped in #51). Memory groups 4 local pages under one dropdown.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle