### PR TITLE
feat(nav): Memory Forum → forum.buildwithoracle.com + cache bump v2 (#60)

### DIFF
--- a/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
@@ -18,7 +18,7 @@ const DEFAULT_NAV: NavSet = {
       label: 'Memory',
       children: [
         { path: '/map', label: 'Map' },
-        { path: '/forum', label: 'Forum' },
+        { path: '/', label: 'Forum', studio: 'forum.buildwithoracle.com' },
         { path: '/activity?tab=searches', label: 'Activity' },
         { path: '/traces', label: 'Traces' },
       ],

--- a/packages/shared-ui/src/components/AppHeader/use-menu.ts
+++ b/packages/shared-ui/src/components/AppHeader/use-menu.ts
@@ -3,7 +3,8 @@ import { apiUrl } from '../../host';
 import { cached } from '../../cache';
 import { buildNavSet, type MenuApiItem, type NavSet } from './nav-types';
 
-const MENU_CACHE_KEY = 'header:menu';
+// v2: 2026-04-20 — Forum child moved to forum.buildwithoracle.com
+const MENU_CACHE_KEY = 'header:menu:v2';
 const MENU_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 /**


### PR DESCRIPTION
## Summary
- DEFAULT_NAV Memory ▾ Forum child now routes cross-origin to `forum.buildwithoracle.com` (was `/forum` on studio).
- Bumped `MENU_CACHE_KEY` from `'header:menu'` → `'header:menu:v2'` (first-ever version bump) so stale browser caches re-fetch `/api/menu`.

Closes part of #60.

## Files
- `packages/shared-ui/src/components/AppHeader/AppHeader.tsx` — DEFAULT_NAV Memory children
- `packages/shared-ui/src/components/AppHeader/use-menu.ts` — cache key + dated comment

## Diff stat
```
 AppHeader.tsx | 2 +-
 use-menu.ts   | 3 ++-
 2 files changed, 3 insertions(+), 2 deletions(-)
```

## Verification
- Grep shared-ui for other `/forum` literals: only the one edited here.
- `bun run build` in `apps/studio` completes cleanly (shared-ui has no own build).

## ⚠️ MERGE GUARD
**MERGE ONLY AFTER all three:**
1. Step 0 — manual DNS record for `forum.buildwithoracle.com` is live.
2. PR1 (`apps/forum/` scaffold) is merged AND deployed to that subdomain.
3. `curl -I https://forum.buildwithoracle.com/` returns HTTP 200.

Merging before the subdomain is live will send Memory ▾ Forum clicks to a non-resolving host.

## Test plan
- [ ] DNS for `forum.buildwithoracle.com` confirmed.
- [ ] PR1 merged + deployed.
- [ ] `curl -I https://forum.buildwithoracle.com/` → 200.
- [ ] After deploy: hard-reload studio, click Memory ▾ Forum, verify cross-origin navigation with `?host=` query preserved.
- [ ] Verify localStorage key `header:menu:v2` written (old `header:menu` ignored/orphaned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)