### PR TITLE
feat(nav): JSON-driven per-app menu order (#68)

### DIFF
--- a/apps/canvas/menu.json
+++ b/apps/canvas/menu.json
@@ -1,0 +1,3 @@
+{
+  "mainOrder": ["Canvas", "Overview", "Search", "Memory", "Feed"]
+}

--- a/apps/canvas/src/components/Header.tsx
+++ b/apps/canvas/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { AppHeader } from '@ui-oracle/shared-ui';
 import { ping } from '../api/oracle';
+import menuConfig from '../../menu.json';
 
 export function Header() {
-  return <AppHeader brandLabel="ARRA 🔮Racle — Canvas" ping={ping} />;
+  return <AppHeader brandLabel="ARRA 🔮Racle — Canvas" ping={ping} menuConfig={menuConfig} />;
 }

--- a/apps/canvas/tsconfig.app.json
+++ b/apps/canvas/tsconfig.app.json
@@ -20,7 +20,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src", "menu.json"]
 }

--- a/apps/feed/menu.json
+++ b/apps/feed/menu.json
@@ -1,0 +1,3 @@
+{
+  "mainOrder": ["Feed", "Memory", "Overview", "Search", "Canvas"]
+}

--- a/apps/feed/src/components/Header.tsx
+++ b/apps/feed/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { AppHeader } from '@ui-oracle/shared-ui';
 import { ping } from '../api/oracle';
+import menuConfig from '../../menu.json';
 
 export function Header() {
-  return <AppHeader brandLabel="ARRA 🔮Racle — Feed" ping={ping} />;
+  return <AppHeader brandLabel="ARRA 🔮Racle — Feed" ping={ping} menuConfig={menuConfig} />;
 }

--- a/apps/feed/tsconfig.app.json
+++ b/apps/feed/tsconfig.app.json
@@ -20,7 +20,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src", "menu.json"]
 }

--- a/apps/forum/menu.json
+++ b/apps/forum/menu.json
@@ -1,0 +1,3 @@
+{
+  "mainOrder": ["Memory", "Overview", "Search", "Canvas", "Feed"]
+}

--- a/apps/forum/src/components/Header.tsx
+++ b/apps/forum/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { AppHeader } from '@ui-oracle/shared-ui';
 import { ping } from '../api/oracle';
+import menuConfig from '../../menu.json';
 
 export function Header() {
-  return <AppHeader brandLabel="ARRA 🔮Racle — Forum" ping={ping} />;
+  return <AppHeader brandLabel="ARRA 🔮Racle — Forum" ping={ping} menuConfig={menuConfig} />;
 }

--- a/apps/forum/tsconfig.app.json
+++ b/apps/forum/tsconfig.app.json
@@ -20,7 +20,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src", "menu.json"]
 }

--- a/apps/schedule/menu.json
+++ b/apps/schedule/menu.json
@@ -1,0 +1,3 @@
+{
+  "toolsOrder": ["Schedule", "Sessions", "Pulse", "Plugins", "Vector Playground", "Compare", "Evolution"]
+}

--- a/apps/schedule/src/components/Header.tsx
+++ b/apps/schedule/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { AppHeader } from '@ui-oracle/shared-ui';
 import { ping } from '../api/oracle';
+import menuConfig from '../../menu.json';
 
 export function Header() {
-  return <AppHeader brandLabel="ARRA 🔮Racle — Schedule" ping={ping} />;
+  return <AppHeader brandLabel="ARRA 🔮Racle — Schedule" ping={ping} menuConfig={menuConfig} />;
 }

--- a/apps/schedule/tsconfig.app.json
+++ b/apps/schedule/tsconfig.app.json
@@ -20,7 +20,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src", "menu.json"]
 }

--- a/apps/studio/menu.json
+++ b/apps/studio/menu.json
@@ -1,0 +1,4 @@
+{
+  "mainOrder": ["Overview", "Search", "Memory", "Canvas", "Feed"],
+  "toolsOrder": ["Schedule", "Pulse", "Sessions", "Plugins", "Vector Playground", "Compare", "Evolution"]
+}

--- a/apps/studio/src/components/Header.tsx
+++ b/apps/studio/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { AppHeader } from '@ui-oracle/shared-ui';
 import { useAuth } from '../contexts/AuthContext';
 import { API_BASE, ping } from '../api/oracle';
+import menuConfig from '../../menu.json';
 
 /** Studio-specific extras: session duration, search/learning counters, settings link, logout. */
 function StudioExtras() {
@@ -80,6 +81,7 @@ export function Header() {
     <AppHeader
       ping={ping}
       topRowExtras={<StudioExtras />}
+      menuConfig={menuConfig}
     />
   );
 }

--- a/apps/studio/tsconfig.app.json
+++ b/apps/studio/tsconfig.app.json
@@ -22,8 +22,9 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true
   },
-  "include": ["src"],
+  "include": ["src", "menu.json"],
   "exclude": ["src/**/__tests__/**", "node_modules", "**/node_modules/**"]
 }

--- a/apps/vector/menu.json
+++ b/apps/vector/menu.json
@@ -1,0 +1,3 @@
+{
+  "toolsOrder": ["Vector Playground", "Compare", "Schedule", "Pulse", "Sessions", "Plugins", "Evolution"]
+}

--- a/apps/vector/src/components/Header.tsx
+++ b/apps/vector/src/components/Header.tsx
@@ -1,12 +1,13 @@
 import { AppHeader, isVectorHost as sharedIsVectorHost } from '@ui-oracle/shared-ui';
 import { ping } from '../api/oracle';
+import menuConfig from '../../menu.json';
 
 /**
  * Vector bundle header — thin wrapper over the shared AppHeader.
  * App-specific wiring: passes the local `ping` fn for the backend chip.
  */
 export function Header() {
-  return <AppHeader brandLabel="ARRA 🔮Racle — Vector" ping={ping} />;
+  return <AppHeader brandLabel="ARRA 🔮Racle — Vector" ping={ping} menuConfig={menuConfig} />;
 }
 
 /** Re-exported for existing imports (VectorSubNav etc.). */

--- a/apps/vector/tsconfig.app.json
+++ b/apps/vector/tsconfig.app.json
@@ -20,7 +20,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src", "menu.json"]
 }

--- a/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useMemo, type ReactNode } from 'react';
 import { hostLabel, isStudioHost, isVectorHost } from '../../host';
 import { Brand } from './Brand';
 import { VersionChip } from './VersionChip';
@@ -8,6 +8,7 @@ import { MainNav } from './MainNav';
 import { ToolsDropdown } from './ToolsDropdown';
 import { useBackendVersion, useMenu } from './use-menu';
 import type { CrossOriginResolver, NavItem, NavSet } from './nav-types';
+import { reorderNavSet, type MenuConfig } from './reorder';
 
 const DEFAULT_NAV: NavSet = {
   main: [
@@ -96,6 +97,8 @@ interface AppHeaderProps {
   crossOriginHref?: CrossOriginResolver;
   /** Hide the "Tools ▾" dropdown. */
   hideToolsDropdown?: boolean;
+  /** Per-app label ordering for main/tools. Unknown labels are ignored. */
+  menuConfig?: MenuConfig;
 }
 
 // Unified cross-origin resolver — preserves BOTH `item.path` and `item.query`
@@ -144,8 +147,10 @@ export function AppHeader({
   fallbackNav = DEFAULT_NAV,
   crossOriginHref = defaultCrossOriginHref,
   hideToolsDropdown = false,
+  menuConfig,
 }: AppHeaderProps) {
   const { nav, loaded } = useMenu(fallbackNav);
+  const reorderedNav = useMemo(() => reorderNavSet(nav, menuConfig), [nav, menuConfig]);
   const backendVersion = useBackendVersion();
 
   return (
@@ -182,11 +187,11 @@ export function AppHeader({
           loaded ? 'opacity-100' : 'opacity-0'
         }`}
       >
-        <MainNav items={nav.main} crossOriginHref={crossOriginHref} />
-        {!hideToolsDropdown && nav.tools.length > 0 && (
+        <MainNav items={reorderedNav.main} crossOriginHref={crossOriginHref} />
+        {!hideToolsDropdown && reorderedNav.tools.length > 0 && (
           <>
             <span className="w-px h-4 bg-border mx-2" />
-            <ToolsDropdown items={nav.tools} crossOriginHref={crossOriginHref} />
+            <ToolsDropdown items={reorderedNav.tools} crossOriginHref={crossOriginHref} />
           </>
         )}
       </nav>

--- a/packages/shared-ui/src/components/AppHeader/__tests__/reorder.test.ts
+++ b/packages/shared-ui/src/components/AppHeader/__tests__/reorder.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'bun:test';
+import { reorderNavSet } from '../reorder';
+import type { NavSet } from '../nav-types';
+
+const nav: NavSet = {
+  main: [
+    { path: '/', label: 'Overview' },
+    { path: '/search', label: 'Search' },
+    { path: '#', label: 'Memory' },
+    { path: '/', label: 'Canvas' },
+    { path: '/', label: 'Feed' },
+  ],
+  tools: [
+    { path: '/', label: 'Schedule' },
+    { path: '/pulse', label: 'Pulse' },
+    { path: '/sessions', label: 'Sessions' },
+    { path: '/plugins', label: 'Plugins' },
+    { path: '/', label: 'Vector Playground' },
+    { path: '/compare', label: 'Compare' },
+    { path: '/evolution', label: 'Evolution' },
+  ],
+};
+
+describe('reorderNavSet', () => {
+  it('returns identity when config is undefined', () => {
+    const out = reorderNavSet(nav);
+    expect(out.main.map((i) => i.label)).toEqual([
+      'Overview', 'Search', 'Memory', 'Canvas', 'Feed',
+    ]);
+    expect(out.tools.map((i) => i.label)).toEqual([
+      'Schedule', 'Pulse', 'Sessions', 'Plugins', 'Vector Playground', 'Compare', 'Evolution',
+    ]);
+  });
+
+  it('returns identity when config orders are empty', () => {
+    const out = reorderNavSet(nav, { mainOrder: [], toolsOrder: [] });
+    expect(out.main.map((i) => i.label)).toEqual([
+      'Overview', 'Search', 'Memory', 'Canvas', 'Feed',
+    ]);
+    expect(out.tools.map((i) => i.label)).toEqual([
+      'Schedule', 'Pulse', 'Sessions', 'Plugins', 'Vector Playground', 'Compare', 'Evolution',
+    ]);
+  });
+
+  it('applies partial config: declared-first, rest preserves original order', () => {
+    const out = reorderNavSet(nav, { mainOrder: ['Feed', 'Memory'] });
+    expect(out.main.map((i) => i.label)).toEqual([
+      'Feed', 'Memory', 'Overview', 'Search', 'Canvas',
+    ]);
+    // tools untouched
+    expect(out.tools.map((i) => i.label)).toEqual([
+      'Schedule', 'Pulse', 'Sessions', 'Plugins', 'Vector Playground', 'Compare', 'Evolution',
+    ]);
+  });
+
+  it('ignores unknown labels in config', () => {
+    const out = reorderNavSet(nav, { mainOrder: ['Nope', 'Feed', 'Phantom'] });
+    expect(out.main.map((i) => i.label)).toEqual([
+      'Feed', 'Overview', 'Search', 'Memory', 'Canvas',
+    ]);
+  });
+
+  it('reorders main and tools independently', () => {
+    const out = reorderNavSet(nav, {
+      mainOrder: ['Canvas'],
+      toolsOrder: ['Vector Playground', 'Compare'],
+    });
+    expect(out.main.map((i) => i.label)).toEqual([
+      'Canvas', 'Overview', 'Search', 'Memory', 'Feed',
+    ]);
+    expect(out.tools.map((i) => i.label)).toEqual([
+      'Vector Playground', 'Compare', 'Schedule', 'Pulse', 'Sessions', 'Plugins', 'Evolution',
+    ]);
+  });
+
+  it('is case sensitive on label match', () => {
+    const out = reorderNavSet(nav, { mainOrder: ['feed', 'MEMORY'] });
+    expect(out.main.map((i) => i.label)).toEqual([
+      'Overview', 'Search', 'Memory', 'Canvas', 'Feed',
+    ]);
+  });
+
+  it('dedupes repeated labels in config (first occurrence wins)', () => {
+    const out = reorderNavSet(nav, { mainOrder: ['Feed', 'Feed', 'Memory'] });
+    expect(out.main.map((i) => i.label)).toEqual([
+      'Feed', 'Memory', 'Overview', 'Search', 'Canvas',
+    ]);
+  });
+});

--- a/packages/shared-ui/src/components/AppHeader/index.ts
+++ b/packages/shared-ui/src/components/AppHeader/index.ts
@@ -10,3 +10,5 @@ export { ToolsDropdown } from './ToolsDropdown';
 export { useMenu, useBackendVersion } from './use-menu';
 export type { NavItem, NavSet, MenuApiItem, CrossOriginResolver } from './nav-types';
 export { buildNavSet, isActivePath } from './nav-types';
+export { reorderNavSet } from './reorder';
+export type { MenuConfig } from './reorder';

--- a/packages/shared-ui/src/components/AppHeader/reorder.ts
+++ b/packages/shared-ui/src/components/AppHeader/reorder.ts
@@ -1,0 +1,34 @@
+import type { NavItem, NavSet } from './nav-types';
+
+export interface MenuConfig {
+  mainOrder?: string[];
+  toolsOrder?: string[];
+}
+
+/**
+ * Pure helper: reorder NavSet by label. Labels in config come first (in the
+ * order given), items not mentioned keep their original relative order after.
+ * Case-sensitive match on item.label. Unknown labels in config are ignored.
+ */
+export function reorderNavSet(navSet: NavSet, config?: MenuConfig): NavSet {
+  return {
+    main: reorderByLabel(navSet.main, config?.mainOrder),
+    tools: reorderByLabel(navSet.tools, config?.toolsOrder),
+  };
+}
+
+function reorderByLabel(items: NavItem[], order?: string[]): NavItem[] {
+  if (!order || order.length === 0) return items;
+  const byLabel = new Map(items.map((i) => [i.label, i]));
+  const declared: NavItem[] = [];
+  const seen = new Set<string>();
+  for (const label of order) {
+    const item = byLabel.get(label);
+    if (item && !seen.has(label)) {
+      declared.push(item);
+      seen.add(label);
+    }
+  }
+  const rest = items.filter((i) => !seen.has(i.label));
+  return [...declared, ...rest];
+}

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -15,6 +15,7 @@ export {
   useBackendVersion,
   buildNavSet,
   isActivePath,
+  reorderNavSet,
 } from './components/AppHeader';
 export type {
   BackendStatus,
@@ -22,6 +23,7 @@ export type {
   NavSet,
   MenuApiItem,
   CrossOriginResolver,
+  MenuConfig,
 } from './components/AppHeader';
 
 // Layout primitives


### PR DESCRIPTION
## Summary

Closes #68.

- Adds `MenuConfig` + `reorderNavSet` pure helper in `packages/shared-ui` (label-based reorder, declared-first, rest preserves original order, unknown labels ignored, case-sensitive).
- Threads a `menuConfig?: MenuConfig` prop through `<AppHeader>` and applies it after `useMenu` resolves (so `/api/menu` still wins on payload; this only reorders).
- Ships `apps/<name>/menu.json` for all 6 apps with sensible per-app priorities:
  - **studio** — default order (explicit for consistency)
  - **feed** — Feed first in main
  - **canvas** — Canvas first in main
  - **schedule** — Schedule first in tools
  - **vector** — Vector Playground + Compare first in tools
  - **forum** — Memory first in main (Forum lives under Memory ▾)
- Each `apps/<name>/tsconfig.app.json` now has `resolveJsonModule: true` and includes `menu.json`.

## Test plan

- [x] `bun test packages/shared-ui/src/components/AppHeader/__tests__/reorder.test.ts` — 7 pass / 0 fail
- [x] `bun install` clean
- [x] `bun run build` clean for **feed**, **canvas**, **forum**, **vector**, **schedule**, **studio** (all 6)
- [ ] Visual QA — confirm each app's header shows the expected order in production (release agent)

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle