### PR TITLE
chore: release v26.4.20-alpha.10 (#68)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-oracle",
-  "version": "26.4.20-alpha.9",
+  "version": "26.4.20-alpha.10",
   "private": true,
   "description": "Oracle UI monorepo — studio, vector, canvas",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump root `package.json` from `26.4.20-alpha.9` → `26.4.20-alpha.10`
- CalVer alpha hour = 10 (per alpha-hours convention)
- Ships JSON menu feature (#68) merged via #69

## Test plan
- [ ] Lead reviews + merges
- [ ] Lead runs `bun run deploy:all` to deploy 6 apps (studio, vector, canvas, schedule, feed, forum)

Refs #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)