### PR TITLE
feat(nav): declarative subnav via menu.json

### DIFF
--- a/apps/vector/menu.json
+++ b/apps/vector/menu.json
@@ -1,3 +1,7 @@
 {
-  "toolsOrder": ["Vector Playground", "Compare", "Schedule", "Pulse", "Sessions", "Plugins", "Evolution"]
+  "toolsOrder": ["Vector Playground", "Compare", "Schedule", "Pulse", "Sessions", "Plugins", "Evolution"],
+  "subnav": [
+    { "path": "/", "label": "Vector Playground", "icon": "🔍" },
+    { "path": "/compare", "label": "Compare", "icon": "⚖️" }
+  ]
 }

--- a/apps/vector/src/App.tsx
+++ b/apps/vector/src/App.tsx
@@ -2,14 +2,12 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Playground from './pages/Playground';
 import Compare from './pages/Compare';
 import { Header } from './components/Header';
-import { VectorSubNav } from './components/VectorSubNav';
 import { BackendGate } from './components/BackendGate';
 
 export default function App() {
   return (
     <BrowserRouter>
       <Header />
-      <VectorSubNav />
       <BackendGate>
         {({ backendLive }) => (
           <Routes>

--- a/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
@@ -11,6 +11,7 @@ import type { CrossOriginResolver, NavItem, NavSet } from './nav-types';
 import { buildNavSet } from './nav-types';
 import bakedMenu from '../../baked-menu';
 import { reorderNavSet, type MenuConfig } from './reorder';
+import { SubNav } from '../SubNav';
 
 const DEFAULT_NAV: NavSet = {
   main: [
@@ -202,6 +203,9 @@ export function AppHeader({
           </>
         )}
       </nav>
+      {menuConfig?.subnav && menuConfig.subnav.length > 0 && (
+        <SubNav items={menuConfig.subnav} />
+      )}
     </header>
   );
 }

--- a/packages/shared-ui/src/components/AppHeader/reorder.ts
+++ b/packages/shared-ui/src/components/AppHeader/reorder.ts
@@ -1,8 +1,10 @@
 import type { NavItem, NavSet } from './nav-types';
+import type { SubNavItem } from '../SubNav';
 
 export interface MenuConfig {
   mainOrder?: string[];
   toolsOrder?: string[];
+  subnav?: SubNavItem[];
 }
 
 /**


### PR DESCRIPTION
## What

SubNav tab strip (currently on vector only via VectorSubNav wrapper) now renders declaratively from \`menuConfig.subnav\` — each app opts in by adding items to its \`apps/<name>/menu.json\`.

Vector migrated from imperative \`<VectorSubNav />\` wrapper to JSON config.

## Enables

Any app can now get vector's sub-nav tab strip by adding to its menu.json:
\`\`\`json
{
  \"subnav\": [
    { \"path\": \"/\", \"label\": \"Page A\", \"icon\": \"🔍\" },
    { \"path\": \"/b\", \"label\": \"Page B\", \"icon\": \"⚖️\" }
  ]
}
\`\`\`

Apps without \`subnav\` render nothing extra — no regressions.

## Scope

- \`packages/shared-ui/src/components/AppHeader/reorder.ts\` — extend MenuConfig with \`subnav?: SubNavItem[]\`
- \`packages/shared-ui/src/components/AppHeader/AppHeader.tsx\` — import SubNav, render below main nav when menuConfig.subnav present
- \`apps/vector/menu.json\` — add subnav for Playground + Compare
- \`apps/vector/src/App.tsx\` — remove \`<VectorSubNav />\` (now auto-rendered by AppHeader)

## Backward compat

\`apps/vector/src/components/VectorSubNav.tsx\` left in place (unused) — can be deleted in follow-up.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle