### PR TITLE
fix(nav): consistent Overview-first + subnav only on canvas/feed/forum

### DIFF
--- a/apps/canvas/menu.json
+++ b/apps/canvas/menu.json
@@ -1,5 +1,4 @@
 {
-  "mainOrder": ["Canvas", "Overview", "Search", "Memory", "Feed"],
   "subnav": [
     { "path": "/?plugin=map", "label": "Map", "icon": "🗺️" },
     { "path": "/?plugin=planets", "label": "Planets", "icon": "🪐" },

--- a/apps/feed/menu.json
+++ b/apps/feed/menu.json
@@ -1,5 +1,4 @@
 {
-  "mainOrder": ["Feed", "Memory", "Overview", "Search", "Canvas"],
   "subnav": [
     { "path": "/", "label": "All", "icon": "📰" },
     { "path": "/?type=principle", "label": "Principles", "icon": "📜" },

--- a/apps/forum/menu.json
+++ b/apps/forum/menu.json
@@ -1,5 +1,4 @@
 {
-  "mainOrder": ["Memory", "Overview", "Search", "Canvas", "Feed"],
   "subnav": [
     { "path": "/", "label": "All Threads", "icon": "💬" },
     { "path": "/?status=open", "label": "Open", "icon": "🟢" },

--- a/apps/schedule/menu.json
+++ b/apps/schedule/menu.json
@@ -1,8 +1,3 @@
 {
-  "toolsOrder": ["Schedule", "Sessions", "Pulse", "Plugins", "Vector Playground", "Compare", "Evolution"],
-  "subnav": [
-    { "path": "/", "label": "Today", "icon": "📅" },
-    { "path": "/?view=upcoming", "label": "Upcoming", "icon": "⏭️" },
-    { "path": "/?view=all", "label": "All", "icon": "📋" }
-  ]
+  "toolsOrder": ["Schedule", "Sessions", "Pulse", "Plugins", "Vector Playground", "Compare", "Evolution"]
 }

--- a/apps/studio/menu.json
+++ b/apps/studio/menu.json
@@ -1,11 +1,3 @@
 {
-  "mainOrder": ["Overview", "Search", "Memory", "Canvas", "Feed"],
-  "toolsOrder": ["Schedule", "Pulse", "Sessions", "Plugins", "Vector Playground", "Compare", "Evolution"],
-  "subnav": [
-    { "path": "/", "label": "Overview", "icon": "◉" },
-    { "path": "/search", "label": "Search", "icon": "🔍" },
-    { "path": "/activity", "label": "Activity", "icon": "📊" },
-    { "path": "/traces", "label": "Traces", "icon": "🔗" },
-    { "path": "/pulse", "label": "Pulse", "icon": "💓" }
-  ]
+  "toolsOrder": ["Schedule", "Pulse", "Sessions", "Plugins", "Vector Playground", "Compare", "Evolution"]
 }

--- a/apps/vector/menu.json
+++ b/apps/vector/menu.json
@@ -1,7 +1,3 @@
 {
-  "toolsOrder": ["Vector Playground", "Compare", "Schedule", "Pulse", "Sessions", "Plugins", "Evolution"],
-  "subnav": [
-    { "path": "/", "label": "Vector Playground", "icon": "🔍" },
-    { "path": "/compare", "label": "Compare", "icon": "⚖️" }
-  ]
+  "toolsOrder": ["Vector Playground", "Compare", "Schedule", "Pulse", "Sessions", "Plugins", "Evolution"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-oracle",
-  "version": "26.4.20-alpha.12",
+  "version": "26.4.20-alpha.13",
   "private": true,
   "description": "Oracle UI monorepo — studio, vector, canvas",
   "type": "module",

--- a/packages/shared-ui/src/components/AppHeader/nav-types.ts
+++ b/packages/shared-ui/src/components/AppHeader/nav-types.ts
@@ -112,7 +112,10 @@ export function buildNavSet(items: MenuApiItem[]): NavSet {
 
   const mainItems = main.map(strip);
   return {
-    main: mainItems.some((n) => n.path === '/' && !n.studio)
+    // Prepend a default Overview only when NO Overview exists. Prior check also
+    // required `!n.studio` which caused duplicate Overview when gist items carry
+    // `studio: 'studio.buildwithoracle.com'` — match by label only.
+    main: mainItems.some((n) => n.label === 'Overview')
       ? mainItems
       : [{ path: '/', label: 'Overview' }, ...mainItems],
     tools: tools.map(strip),


### PR DESCRIPTION
User fatigue-pass findings:
- Fixed duplicate Overview on vector/schedule (buildNavSet dedupe check)
- Dropped all mainOrder overrides for consistent Overview-first everywhere
- Hid subnav on studio/vector/schedule — keep only on canvas/feed/forum where sub-routes have genuine UX value

Bundles v26.4.20-alpha.13 release.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle