### PR TITLE
fix(nav): SubNav active-state honors query params (#77)

### DIFF
--- a/packages/shared-ui/src/components/SubNav-active.ts
+++ b/packages/shared-ui/src/components/SubNav-active.ts
@@ -1,0 +1,20 @@
+/**
+ * Active if pathname matches AND every query param declared on the item is
+ * present with the same value on the current URL. Item paths without a query
+ * string fall back to pathname-only comparison.
+ */
+export function isSubNavItemActive(
+  itemPath: string,
+  currentPath: string,
+  currentSearch: string,
+): boolean {
+  const [cleanPath, queryStr] = itemPath.split('?');
+  if (currentPath !== cleanPath) return false;
+  if (!queryStr) return true;
+  const itemParams = new URLSearchParams(queryStr);
+  const currentParams = new URLSearchParams(currentSearch);
+  for (const [k, v] of itemParams.entries()) {
+    if (currentParams.get(k) !== v) return false;
+  }
+  return true;
+}

--- a/packages/shared-ui/src/components/SubNav.tsx
+++ b/packages/shared-ui/src/components/SubNav.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation } from 'react-router-dom';
+import { isSubNavItemActive } from './SubNav-active';
 
 export type SubNavItem = { path: string; label: string; icon?: string };
 
@@ -16,6 +17,9 @@ export function SubNav({ items, enabled = true }: Props) {
   const location = useLocation();
   if (!enabled) return null;
 
+  const currentSearch =
+    typeof window !== 'undefined' ? window.location.search : '';
+
   return (
     <div
       className="sticky top-[92px] z-40 backdrop-blur-xl"
@@ -26,7 +30,7 @@ export function SubNav({ items, enabled = true }: Props) {
     >
       <nav className="flex items-center gap-1.5 px-6 py-2 max-w-[1400px] mx-auto overflow-x-auto">
         {items.map((it) => {
-          const active = location.pathname === it.path;
+          const active = isSubNavItemActive(it.path, location.pathname, currentSearch);
           return (
             <Link
               key={it.path}

--- a/packages/shared-ui/src/components/__tests__/SubNav-active.test.ts
+++ b/packages/shared-ui/src/components/__tests__/SubNav-active.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'bun:test';
+import { isSubNavItemActive } from '../SubNav-active';
+
+describe('isSubNavItemActive', () => {
+  it('matches plain pathname when item has no query', () => {
+    expect(isSubNavItemActive('/pulse', '/pulse', '')).toBe(true);
+    expect(isSubNavItemActive('/pulse', '/pulse', '?unused=1')).toBe(true);
+  });
+
+  it('rejects when pathname differs', () => {
+    expect(isSubNavItemActive('/pulse', '/compare', '')).toBe(false);
+    expect(isSubNavItemActive('/?plugin=map', '/other', '?plugin=map')).toBe(false);
+  });
+
+  it('matches query-scoped item when current search has the same param', () => {
+    expect(isSubNavItemActive('/?plugin=map', '/', '?plugin=map')).toBe(true);
+  });
+
+  it('rejects query-scoped item when current param value differs', () => {
+    expect(isSubNavItemActive('/?plugin=map', '/', '?plugin=graph')).toBe(false);
+  });
+
+  it('rejects query-scoped item when current search lacks the param', () => {
+    expect(isSubNavItemActive('/?plugin=map', '/', '')).toBe(false);
+  });
+
+  it('requires every item param to match (subset semantics)', () => {
+    expect(isSubNavItemActive('/?plugin=map&mode=edit', '/', '?plugin=map&mode=edit&extra=1')).toBe(true);
+    expect(isSubNavItemActive('/?plugin=map&mode=edit', '/', '?plugin=map')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Canvas plugin tabs (`/?plugin=map`) never highlighted because active check compared `location.pathname` against the full item path including the query string.
- Extract `isSubNavItemActive(itemPath, currentPath, currentSearch)` as a pure helper in `SubNav-active.ts`: split on `?`, compare pathname, then verify every declared query param matches the current URL. Items with no query fall back to pathname-only.
- `SubNav` feeds `location.pathname` + `window.location.search` (guarded for SSR) into the helper.

## Test plan
- [x] `bun test packages/shared-ui/src/components/__tests__/SubNav-active.test.ts` — 6 pass / 0 fail
- [x] `bun --cwd apps/canvas run build` clean (tsc + vite, no errors)
- [ ] Manual: visit canvas `/?plugin=map` and confirm the Map tab highlights; switch to `/?plugin=graph` and confirm it swaps.

Closes #77

🤖 ตอบโดย arra-oracle-v3 จาก [Nat Weerawan] → arra-oracle-v3-oracle