### PR TITLE
fix(host): auto-derive default backend from window.location (#82)

### DIFF
--- a/packages/shared-ui/src/host.ts
+++ b/packages/shared-ui/src/host.ts
@@ -13,7 +13,20 @@
 const STORAGE_KEY = 'oracle-studio-host';
 const RECENT_KEY = 'oracle-studio-host-recent';
 const RECENT_LIMIT = 8;
-const DEFAULT_HOST = 'http://localhost:47778';
+
+// Auto-derive default backend host from the page's own URL so the studio works
+// from any reachable hostname (m5.wg, mba.local, an IP, ...) without per-peer
+// localStorage / `?host=` setup. Falls back to literal localhost during SSR /
+// non-browser contexts. An explicit env override still wins via
+// import.meta.env.VITE_DEFAULT_HOST when teams want to pin a deployment.
+const ENV_DEFAULT =
+  typeof import.meta !== 'undefined' &&
+  (import.meta as { env?: { VITE_DEFAULT_HOST?: string } }).env?.VITE_DEFAULT_HOST;
+const DEFAULT_HOST: string =
+  ENV_DEFAULT ||
+  (typeof window !== 'undefined'
+    ? `${window.location.protocol}//${window.location.hostname}:47778`
+    : 'http://localhost:47778');
 
 const params =
   typeof window !== 'undefined'


### PR DESCRIPTION
## Summary

Closes #82.

`packages/shared-ui/src/host.ts` previously hardcoded `DEFAULT_HOST = 'http://localhost:47778'`. That only works when the studio is loaded from the same machine running arra-http; loading from a wg peer or LAN box made the browser try ITS own localhost.

This change derives the default from `window.location` so the studio fetches from whatever hostname it loaded from. localhost path unchanged for solo dev. Existing `?host=...` and localStorage overrides still win when set. Adds `VITE_DEFAULT_HOST` as an explicit env override for pinned deployments.

## Test plan

- [x] localhost path unchanged: `http://localhost:3000/` → derives `http://localhost:47778` (same as before)
- [ ] m5.wg path: `http://m5.wg:3000/` → derives `http://m5.wg:47778` (post-merge verify on m5)
- [ ] mba access: `http://m5.wg:3000/` from another wg peer → derives correctly without ?host= dance
- [ ] localStorage override still wins when set
- [ ] `?host=...` URL param still wins and gets cleaned

Closes #82

---

🤖 ตอบโดย maw-m5 จาก Nat → maw-m5-oracle