### PR TITLE
Prevent indexer API paths from falling through to SPA HTML

### DIFF
--- a/apps/indexer/worker.ts
+++ b/apps/indexer/worker.ts
@@ -2,12 +2,29 @@ interface Env {
   ASSETS: { fetch: (request: Request) => Promise<Response> };
 }
 
+const HELP = {
+  error: "API not available on deployed indexer",
+  message:
+    "indexer.buildwithoracle.com is the indexer UI — run the backend locally via " +
+    "`bunx --bun arra-oracle-v3@github:Soul-Brews-Studio/arra-oracle-v3`, " +
+    "default localhost:47778, set ?host= to override.",
+  docs: "https://neo.buildwithoracle.com/install/",
+};
+
 // Hashed by Vite — safe to cache forever. Covers /assets/* and *-[hash].{js,css,png,woff2,...}
 const HASHED_ASSET = /\/(?:assets\/|[^/]+-)[A-Za-z0-9_-]{8,}\.[a-z0-9]+$/i;
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
+
+    if (url.pathname.startsWith("/api/") || url.pathname === "/api") {
+      return Response.json(HELP, {
+        status: 404,
+        headers: { "cache-control": "no-store" },
+      });
+    }
+
     const response = await env.ASSETS.fetch(request);
     if (!response.ok) return response;
 


### PR DESCRIPTION
## Summary
- Add an indexer worker HELP payload for deployed static-SPA API requests
- Short-circuit `/api` and `/api/*` before `ASSETS.fetch` so SPA fallback cannot return misleading 200 HTML
- Match the studio static-deploy precedent with `404` JSON and `cache-control: no-store`

## Verification
- `git diff --check -- apps/indexer/worker.ts`
- `bun -e 'import worker from "./apps/indexer/worker.ts"; const res = await worker.fetch(new Request("https://indexer.buildwithoracle.com/api/health"), { ASSETS: { fetch: async () => new Response("asset", {status: 200}) } }); console.log(JSON.stringify({status: res.status, contentType: res.headers.get("content-type"), cacheControl: res.headers.get("cache-control"), body: await res.json()}));'`

## Known gap
- `bun run build` from `apps/indexer` currently fails before this change with missing `src/index.css` and shared-ui `__APP_VERSION__` type errors.