### PR TITLE
fix(indexer): add missing vite-env.d.ts so build passes

### DIFF
--- a/apps/indexer/src/vite-env.d.ts
+++ b/apps/indexer/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/apps/indexer/tsconfig.app.json
+++ b/apps/indexer/tsconfig.app.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
Completes the indexer deploy-gap fix from #91.

#91 added the missing root `deploy:indexer` script — but deploying then revealed indexer's **own build was broken**: it was the only app with no `src/vite-env.d.ts`, so `tsc -b` failed with:

- `Cannot find name '__APP_VERSION__'` in shared-ui (`cached.ts`, `VersionChip.tsx`) — no `declare const __APP_VERSION__`
- `Cannot find module './index.css'` — no `/// <reference types="vite/client" />`

It had only been shipping via a stale incremental `tsbuildinfo` that skipped the type check (the mystery untracked `apps/indexer/tsconfig.app.tsbuildinfo`).

**Fix:** add the standard `vite-env.d.ts` (identical to every sibling app) + point `tsBuildInfoFile` at `node_modules/.tmp` so it stops dropping a stray artifact at the app root.

✅ `tsc -b && vite build` now green · indexer redeployed live to indexer.buildwithoracle.com (Version `9b0f4e62`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)