### PR TITLE
feat(all): ARRA Oracle combined bundle — all 7 apps in one, still splittable

### DIFF
--- a/apps/all/index.html
+++ b/apps/all/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%23101020'/><text x='50' y='72' font-size='62' font-family='system-ui' font-weight='700' fill='%23a78bfa' text-anchor='middle'>A</text></svg>">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ARRA 🔮Racle</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/all/package.json
+++ b/apps/all/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "all-oracle-studio",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Combined bundle — app.buildwithoracle.com",
+  "engines": {
+    "bun": ">=1.2.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Soul-Brews-Studio/ui-oracle.git"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "deploy": "bun run build && wrangler deploy"
+  },
+  "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@types/three": "^0.182.0",
+    "@ui-oracle/shared-ui": "workspace:*",
+    "knowledge-map-3d": "github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D",
+    "ml5": "1",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "react-markdown": "^10.1.0",
+    "react-router-dom": "^7.11.0",
+    "recharts": "^3.6.0",
+    "remark-gfm": "^4.0.1",
+    "three": "^0.182.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.2.1",
+    "@types/bun": "^1.3.12",
+    "@types/node": "^24.10.1",
+    "@types/react": "^19.2.5",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "tailwindcss": "^4.2.1",
+    "typescript": "~5.9.3",
+    "vite": "^7.2.4"
+  },
+  "author": "Soul Brews Studio",
+  "license": "BUSL-1.1"
+}

--- a/apps/all/src/App.tsx
+++ b/apps/all/src/App.tsx
@@ -1,0 +1,84 @@
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BasePathProvider } from '@ui-oracle/shared-ui';
+import { CombinedHeader } from './CombinedHeader';
+
+import { StudioRoutes } from '../../studio/src/App';
+import { VectorRoutes } from '../../vector/src/App';
+import { CanvasRoutes } from '../../canvas/src/App';
+import { FeedRoutes } from '../../feed/src/App';
+import { ForumRoutes } from '../../forum/src/App';
+import { ScheduleRoutes } from '../../schedule/src/App';
+import { IndexerRoutes } from '../../indexer/src/App';
+
+/**
+ * The combined single-origin bundle. ONE <BrowserRouter> hosts every app under
+ * its own base path. Each mounted fragment is wrapped in a <BasePathProvider>
+ * so its internal links/redirects stay scoped. Apps that wrap their own
+ * BackendGate/AuthProvider (studio, vector) keep doing so — we don't double-wrap.
+ */
+export default function App() {
+  return (
+    <BrowserRouter>
+      <CombinedHeader />
+      <Routes>
+        <Route
+          path="/studio/*"
+          element={
+            <BasePathProvider value="/studio">
+              <StudioRoutes />
+            </BasePathProvider>
+          }
+        />
+        <Route
+          path="/vector/*"
+          element={
+            <BasePathProvider value="/vector">
+              <VectorRoutes />
+            </BasePathProvider>
+          }
+        />
+        <Route
+          path="/canvas/*"
+          element={
+            <BasePathProvider value="/canvas">
+              <CanvasRoutes />
+            </BasePathProvider>
+          }
+        />
+        <Route
+          path="/feed/*"
+          element={
+            <BasePathProvider value="/feed">
+              <FeedRoutes />
+            </BasePathProvider>
+          }
+        />
+        <Route
+          path="/forum/*"
+          element={
+            <BasePathProvider value="/forum">
+              <ForumRoutes />
+            </BasePathProvider>
+          }
+        />
+        <Route
+          path="/schedule/*"
+          element={
+            <BasePathProvider value="/schedule">
+              <ScheduleRoutes />
+            </BasePathProvider>
+          }
+        />
+        <Route
+          path="/indexer/*"
+          element={
+            <BasePathProvider value="/indexer">
+              <IndexerRoutes />
+            </BasePathProvider>
+          }
+        />
+        <Route path="/" element={<Navigate to="/studio" replace />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/apps/all/src/CombinedHeader.tsx
+++ b/apps/all/src/CombinedHeader.tsx
@@ -1,0 +1,21 @@
+import { AppHeader, apiUrl } from '@ui-oracle/shared-ui';
+import { inAppHref } from './nav-map';
+
+/** Backend reachability probe for the live/demo chip. */
+async function ping(): Promise<boolean> {
+  try {
+    const res = await fetch(apiUrl('/api/stats'), { signal: AbortSignal.timeout(2000) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * One unified top nav for the combined bundle. Runs the shared AppHeader in
+ * combinedMode so every nav item routes same-origin via inAppHref (→ /studio,
+ * /vector, …) instead of bouncing across subdomains.
+ */
+export function CombinedHeader() {
+  return <AppHeader ping={ping} combinedMode inAppHref={inAppHref} />;
+}

--- a/apps/all/src/index.css
+++ b/apps/all/src/index.css
@@ -1,0 +1,71 @@
+@import "tailwindcss";
+@source "../../../packages/shared-ui/src/**/*.{ts,tsx}";
+@source "../../studio/src/**/*.{ts,tsx}";
+@source "../../vector/src/**/*.{ts,tsx}";
+@source "../../canvas/src/**/*.{ts,tsx}";
+@source "../../feed/src/**/*.{ts,tsx}";
+@source "../../forum/src/**/*.{ts,tsx}";
+@source "../../schedule/src/**/*.{ts,tsx}";
+@source "../../indexer/src/**/*.{ts,tsx}";
+
+@theme {
+  --color-bg-primary: #0a0a0f;
+  --color-bg-secondary: #0f0f1a;
+  --color-bg-card: #0f0f14;
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-border-subtle: rgba(255, 255, 255, 0.04);
+  --color-border-hover: rgba(255, 255, 255, 0.12);
+  --color-accent: #64b5f6;
+  --color-accent-hover: #42a5f5;
+  --color-success: #4ade80;
+  --color-warning: #fbbf24;
+  --color-text-primary: #e8e8ee;
+  --color-text-secondary: #9aa0ab;
+  --color-text-muted: #6b7280;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  min-height: 100vh;
+  line-height: 1.6;
+  background-image:
+    radial-gradient(at 15% 10%, rgba(96, 165, 250, 0.10) 0px, transparent 55%),
+    radial-gradient(at 85% 20%, rgba(167, 139, 250, 0.10) 0px, transparent 55%),
+    radial-gradient(at 50% 90%, rgba(74, 222, 128, 0.08) 0px, transparent 60%),
+    linear-gradient(180deg, #07070c 0%, #0a0a10 100%);
+  background-attachment: fixed;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.1); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.2); }
+* { scrollbar-width: thin; scrollbar-color: rgba(255, 255, 255, 0.1) transparent; }
+
+/* Playground animations */
+@keyframes gradientShift {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+@keyframes glowPulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}
+@keyframes badgePulse {
+  0%, 100% { opacity: 0.8; }
+  50% { opacity: 1; }
+}
+@keyframes float {
+  0%, 100% { transform: translateY(0px); }
+  50% { transform: translateY(-6px); }
+}

--- a/apps/all/src/main.tsx
+++ b/apps/all/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/apps/all/src/nav-map.ts
+++ b/apps/all/src/nav-map.ts
@@ -1,0 +1,39 @@
+import type { NavItem } from '@ui-oracle/shared-ui';
+
+/**
+ * Maps the cross-origin `studio` host on each NavItem to the in-app base path
+ * used by the combined bundle. Items without a `studio` host resolve against
+ * the empty base (i.e. their `path` is used verbatim).
+ */
+export const SUBDOMAIN_TO_BASE: Record<string, string> = {
+  'studio.buildwithoracle.com': '/studio',
+  'vector.buildwithoracle.com': '/vector',
+  'canvas.buildwithoracle.com': '/canvas',
+  'feed.buildwithoracle.com': '/feed',
+  'forum.buildwithoracle.com': '/forum',
+  'schedule.buildwithoracle.com': '/schedule',
+  'indexer.buildwithoracle.com': '/indexer',
+};
+
+/**
+ * In-app href resolver for the combined bundle. Translates a NavItem into a
+ * same-origin path: base (from its `studio` host) + the item's path, with any
+ * `query` appended as `?k=v`.
+ */
+export function inAppHref(item: NavItem): string {
+  const base = (item.studio ? SUBDOMAIN_TO_BASE[item.studio] : undefined) ?? '';
+  let href = base + item.path;
+
+  if (item.query) {
+    const entries = Object.entries(item.query);
+    if (entries.length > 0) {
+      const sep = href.includes('?') ? '&' : '?';
+      const qs = entries
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join('&');
+      href = `${href}${sep}${qs}`;
+    }
+  }
+
+  return href;
+}

--- a/apps/all/src/vite-env.d.ts
+++ b/apps/all/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/apps/all/tsconfig.app.json
+++ b/apps/all/tsconfig.app.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "types": ["vite/client", "bun"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src", "../studio/src", "../vector/src", "../canvas/src", "../feed/src", "../forum/src", "../schedule/src", "../indexer/src"],
+  "exclude": [
+    "src/**/__tests__/**",
+    "../studio/src/**/__tests__/**",
+    "../vector/src/**/__tests__/**",
+    "../canvas/src/**/__tests__/**",
+    "../feed/src/**/__tests__/**",
+    "../forum/src/**/__tests__/**",
+    "../schedule/src/**/__tests__/**",
+    "../indexer/src/**/__tests__/**",
+    "node_modules",
+    "**/node_modules/**"
+  ]
+}

--- a/apps/all/tsconfig.json
+++ b/apps/all/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/apps/all/tsconfig.node.json
+++ b/apps/all/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/all/vite.config.ts
+++ b/apps/all/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'))
+const gitHash = (() => {
+  try { return execSync('git rev-parse --short HEAD').toString().trim() }
+  catch { return 'dev' }
+})()
+const appVersion = `v${pkg.version}+${gitHash}`
+
+export default defineConfig({
+  plugins: [tailwindcss(), react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
+  server: {
+    port: 5181,
+    allowedHosts: true,
+  },
+})

--- a/apps/all/worker.ts
+++ b/apps/all/worker.ts
@@ -1,0 +1,27 @@
+interface Env {
+  ASSETS: { fetch: (request: Request) => Promise<Response> };
+}
+
+const HASHED_ASSET = /\/(?:assets\/|[^/]+-)[A-Za-z0-9_-]{8,}\.[a-z0-9]+$/i;
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const response = await env.ASSETS.fetch(request);
+    if (!response.ok) return response;
+
+    const headers = new Headers(response.headers);
+
+    if (HASHED_ASSET.test(url.pathname)) {
+      headers.set("cache-control", "public, max-age=31536000, immutable");
+    } else {
+      headers.set("cache-control", "public, max-age=3600, stale-while-revalidate=86400");
+    }
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  },
+};

--- a/apps/all/wrangler.json
+++ b/apps/all/wrangler.json
@@ -1,0 +1,19 @@
+{
+  "name": "all-oracle-studio",
+  "main": "worker.ts",
+  "compatibility_date": "2025-06-01",
+  "account_id": "a5eabdc2b11aae9bd5af46bd6a88179e",
+  "workers_dev": true,
+  "routes": [
+    {
+      "pattern": "app.buildwithoracle.com",
+      "custom_domain": true
+    }
+  ],
+  "assets": {
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
+  }
+}

--- a/apps/canvas/src/App.tsx
+++ b/apps/canvas/src/App.tsx
@@ -1,15 +1,24 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BasePathProvider } from '@ui-oracle/shared-ui';
 import CanvasHost from './pages/CanvasHost';
 import { Header } from './components/Header';
+
+export function CanvasRoutes() {
+  return (
+    <Routes>
+      <Route index element={<CanvasHost />} />
+      <Route path="*" element={<CanvasHost />} />
+    </Routes>
+  );
+}
 
 export default function App() {
   return (
     <BrowserRouter>
-      <Header />
-      <Routes>
-        <Route path="/" element={<CanvasHost />} />
-        <Route path="*" element={<CanvasHost />} />
-      </Routes>
+      <BasePathProvider value="">
+        <Header />
+        <CanvasRoutes />
+      </BasePathProvider>
     </BrowserRouter>
   );
 }

--- a/apps/canvas/src/pages/CanvasHost.tsx
+++ b/apps/canvas/src/pages/CanvasHost.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { AppLink as Link } from '@ui-oracle/shared-ui';
 import * as THREE from 'three';
 import {
   DEFAULT_PLUGIN_ID,

--- a/apps/canvas/src/plugins/react/MapPlugin.tsx
+++ b/apps/canvas/src/plugins/react/MapPlugin.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { KnowledgeMap } from 'knowledge-map-3d';
+import { useBase, useNavTo, withBase } from '@ui-oracle/shared-ui';
 import { usePlanetsData } from '../../hooks/usePlanetsData';
 import { usePlanetsSearch } from '../../hooks/usePlanetsSearch';
 import { PlanetsLoading, PlanetsEmpty } from '../../components/planets/PlanetsEmpty';
@@ -9,6 +10,8 @@ import { TYPE_COLORS } from '../../lib/type-colors';
 export function MapPlugin() {
   const data = usePlanetsData();
   const search = usePlanetsSearch();
+  const base = useBase();
+  const navigate = useNavTo();
   const [visibleTypes, setVisibleTypes] = useState<Set<string>>(() => new Set(Object.keys(TYPE_COLORS)));
 
   const filteredDocs = useMemo(
@@ -36,7 +39,11 @@ export function MapPlugin() {
         nebulae={data.nebulae}
         highlightIds={search.matchIds}
         onDocumentClick={(doc) => {
-          window.location.href = `/doc/${encodeURIComponent(doc.id)}`;
+          if (base) {
+            navigate(withBase(base, `/studio/doc/${encodeURIComponent(doc.id)}`));
+          } else {
+            window.location.href = `/doc/${encodeURIComponent(doc.id)}`;
+          }
         }}
         typeColors={TYPE_COLORS}
         embedded

--- a/apps/canvas/src/plugins/react/PlanetsPlugin.tsx
+++ b/apps/canvas/src/plugins/react/PlanetsPlugin.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
+import { useBase, useNavTo, withBase } from '@ui-oracle/shared-ui';
 import { usePlanetsData } from '../../hooks/usePlanetsData';
 import { usePlanetsSearch } from '../../hooks/usePlanetsSearch';
 import { PlanetsCanvas } from '../../components/planets/PlanetsCanvas';
@@ -11,6 +12,8 @@ import { TYPE_COLORS } from '../../lib/type-colors';
 export function PlanetsPlugin() {
   const data = usePlanetsData();
   const search = usePlanetsSearch();
+  const base = useBase();
+  const navigate = useNavTo();
   const [visibleTypes, setVisibleTypes] = useState<Set<string>>(() => new Set(Object.keys(TYPE_COLORS)));
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
 
@@ -50,7 +53,11 @@ export function PlanetsPlugin() {
           nebulae={data.nebulae}
           highlightIds={search.matchIds}
           onDocumentClick={(doc) => {
-            window.location.href = `/doc/${encodeURIComponent(doc.id)}`;
+            if (base) {
+              navigate(withBase(base, `/studio/doc/${encodeURIComponent(doc.id)}`));
+            } else {
+              window.location.href = `/doc/${encodeURIComponent(doc.id)}`;
+            }
           }}
         />
         <PlanetsHUD

--- a/apps/feed/src/App.tsx
+++ b/apps/feed/src/App.tsx
@@ -1,17 +1,26 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BasePathProvider } from '@ui-oracle/shared-ui';
 import { Feed } from './pages/Feed';
 import { DocRedirect } from './pages/DocRedirect';
 import { Header } from './components/Header';
 
+export function FeedRoutes() {
+  return (
+    <Routes>
+      <Route index element={<Feed />} />
+      <Route path="doc/:id" element={<DocRedirect />} />
+      <Route path="*" element={<Feed />} />
+    </Routes>
+  );
+}
+
 export default function App() {
   return (
     <BrowserRouter>
-      <Header />
-      <Routes>
-        <Route path="/" element={<Feed />} />
-        <Route path="/doc/:id" element={<DocRedirect />} />
-        <Route path="*" element={<Feed />} />
-      </Routes>
+      <BasePathProvider value="">
+        <Header />
+        <FeedRoutes />
+      </BasePathProvider>
     </BrowserRouter>
   );
 }

--- a/apps/feed/src/components/LogCard.tsx
+++ b/apps/feed/src/components/LogCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { AppLink as Link } from '@ui-oracle/shared-ui';
 import type { Document } from '../api/oracle';
 import { getDocDisplayInfo } from '../utils/docDisplay';
 import styles from './LogCard.module.css';

--- a/apps/feed/src/components/SidebarLayout.tsx
+++ b/apps/feed/src/components/SidebarLayout.tsx
@@ -1,4 +1,5 @@
-import { Link, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { AppLink as Link, useBase, withBase } from '@ui-oracle/shared-ui';
 
 const DEFAULT_TYPES = [
   { key: 'all', label: 'All' },
@@ -45,6 +46,7 @@ export function SidebarLayout({
   navItems,
 }: SidebarLayoutProps) {
   const location = useLocation();
+  const base = useBase();
 
   return (
     <div className="max-w-[900px] mx-auto px-6 py-8 max-md:px-3 max-md:py-4">
@@ -57,7 +59,7 @@ export function SidebarLayout({
                 key={item.path}
                 to={item.path}
                 className={`px-3 py-1.5 rounded-lg text-[13px] transition-all duration-150 ${
-                  location.pathname === item.path
+                  location.pathname === withBase(base, item.path)
                     ? 'bg-bg-card text-accent font-medium'
                     : 'text-text-secondary hover:bg-bg-card hover:text-text-primary'
                 }`}

--- a/apps/feed/src/pages/DocRedirect.tsx
+++ b/apps/feed/src/pages/DocRedirect.tsx
@@ -1,15 +1,24 @@
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import { useBase, withBase, useNavTo } from '@ui-oracle/shared-ui';
 
 const STUDIO_ORIGIN = 'https://studio.buildwithoracle.com';
 
 export function DocRedirect() {
   const { id } = useParams<{ id: string }>();
+  const base = useBase();
+  const navigate = useNavTo();
   useEffect(() => {
     if (id) {
-      window.location.replace(`${STUDIO_ORIGIN}/doc/${id}`);
+      if (base) {
+        // Combined mode: studio is mounted in the same bundle — navigate in-app.
+        navigate(withBase(base, `/studio/doc/${id}`), { replace: true });
+      } else {
+        // Standalone: hard-redirect to the studio subdomain.
+        window.location.replace(`${STUDIO_ORIGIN}/doc/${id}`);
+      }
     }
-  }, [id]);
+  }, [id, base, navigate]);
   return (
     <div className="max-w-[1300px] mx-auto py-10 px-6 text-text-secondary">
       <p className="text-sm">Redirecting to <a className="text-accent underline" href={STUDIO_ORIGIN}>studio</a>…</p>

--- a/apps/forum/src/App.tsx
+++ b/apps/forum/src/App.tsx
@@ -1,15 +1,24 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BasePathProvider } from '@ui-oracle/shared-ui';
 import { Forum } from './pages/Forum';
 import { Header } from './components/Header';
+
+export function ForumRoutes() {
+  return (
+    <Routes>
+      <Route index element={<Forum />} />
+      <Route path="*" element={<Forum />} />
+    </Routes>
+  );
+}
 
 export default function App() {
   return (
     <BrowserRouter>
-      <Header />
-      <Routes>
-        <Route path="/" element={<Forum />} />
-        <Route path="*" element={<Forum />} />
-      </Routes>
+      <BasePathProvider value="">
+        <Header />
+        <ForumRoutes />
+      </BasePathProvider>
     </BrowserRouter>
   );
 }

--- a/apps/indexer/src/App.tsx
+++ b/apps/indexer/src/App.tsx
@@ -1,13 +1,22 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BasePathProvider } from '@ui-oracle/shared-ui';
 import Indexer from './pages/Indexer';
+
+export function IndexerRoutes() {
+  return (
+    <Routes>
+      <Route index element={<Indexer />} />
+      <Route path="*" element={<Indexer />} />
+    </Routes>
+  );
+}
 
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Indexer />} />
-        <Route path="*" element={<Indexer />} />
-      </Routes>
+      <BasePathProvider value="">
+        <IndexerRoutes />
+      </BasePathProvider>
     </BrowserRouter>
   );
 }

--- a/apps/indexer/src/vite-env.d.ts
+++ b/apps/indexer/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/apps/indexer/tsconfig.app.json
+++ b/apps/indexer/tsconfig.app.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],

--- a/apps/schedule/src/App.tsx
+++ b/apps/schedule/src/App.tsx
@@ -1,15 +1,24 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BasePathProvider } from '@ui-oracle/shared-ui';
 import Schedule from './pages/Schedule';
 import { Header } from './components/Header';
+
+export function ScheduleRoutes() {
+  return (
+    <Routes>
+      <Route index element={<Schedule />} />
+      <Route path="*" element={<Schedule />} />
+    </Routes>
+  );
+}
 
 export default function App() {
   return (
     <BrowserRouter>
-      <Header />
-      <Routes>
-        <Route path="/" element={<Schedule />} />
-        <Route path="*" element={<Schedule />} />
-      </Routes>
+      <BasePathProvider value="">
+        <Header />
+        <ScheduleRoutes />
+      </BasePathProvider>
     </BrowserRouter>
   );
 }

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { BasePathProvider, useBase, withBase } from '@ui-oracle/shared-ui';
 import { Header } from './components/Header';
 
 import { Overview } from './pages/Overview';
@@ -33,21 +34,21 @@ import { setVaultRepo } from './utils/docDisplay';
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, authEnabled, isLoading } = useAuth();
   const location = useLocation();
+  const base = useBase();
 
   if (isLoading) {
     return <div style={{ padding: 48, textAlign: 'center', color: '#888' }}>Loading...</div>;
   }
 
   if (authEnabled && !isAuthenticated) {
-    return <Navigate to="/login" state={{ from: location }} replace />;
+    return <Navigate to={withBase(base, '/login')} state={{ from: location }} replace />;
   }
 
   return <>{children}</>;
 }
 
-function AppContent() {
-  const location = useLocation();
-  const isLoginPage = location.pathname === '/login';
+// ⌘K command palette — shared by standalone and combined mounts.
+function CommandPaletteHotkey() {
   const [showCmdK, setShowCmdK] = useState(false);
 
   useEffect(() => {
@@ -61,43 +62,29 @@ function AppContent() {
     return () => window.removeEventListener('keydown', handler);
   }, []);
 
-  return (
-    <>
-      {!isLoginPage && <Header />}
-      {showCmdK && <CommandPalette onClose={() => setShowCmdK(false)} />}
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route path="/" element={<RequireAuth><Overview /></RequireAuth>} />
-        <Route path="/feed" element={<RequireAuth><Feed /></RequireAuth>} />
-        <Route path="/doc/:id" element={<RequireAuth><DocDetail /></RequireAuth>} />
-        <Route path="/search" element={<RequireAuth><Search /></RequireAuth>} />
-        <Route path="/playground" element={<RequireAuth><Playground /></RequireAuth>} />
-        <Route path="/compare" element={<RequireAuth><Compare /></RequireAuth>} />
-        <Route path="/map" element={<RequireAuth><Map /></RequireAuth>} />
-        <Route path="/graph" element={<Navigate to="/map" replace />} />
-        <Route path="/graph3d" element={<Navigate to="/map" replace />} />
-        <Route path="/handoff" element={<RequireAuth><Handoff /></RequireAuth>} />
-        <Route path="/activity" element={<RequireAuth><Activity /></RequireAuth>} />
-        <Route path="/evolution" element={<RequireAuth><Evolution /></RequireAuth>} />
-        <Route path="/traces" element={<RequireAuth><Traces /></RequireAuth>} />
-        <Route path="/traces/:id" element={<RequireAuth><Traces /></RequireAuth>} />
-        <Route path="/superseded" element={<RequireAuth><Superseded /></RequireAuth>} />
-        <Route path="/pulse" element={<RequireAuth><Pulse /></RequireAuth>} />
-        <Route path="/sessions" element={<RequireAuth><Sessions /></RequireAuth>} />
-        <Route path="/sessions/:id" element={<RequireAuth><Sessions /></RequireAuth>} />
-        <Route path="/canvas" element={<RequireAuth><Canvas /></RequireAuth>} />
-        <Route path="/planets" element={<RequireAuth><Planets /></RequireAuth>} />
-        <Route path="/plugins" element={<RequireAuth><Plugins /></RequireAuth>} />
-        <Route path="/schedule" element={<RequireAuth><Schedule /></RequireAuth>} />
-        <Route path="/settings" element={<RequireAuth><Settings /></RequireAuth>} />
-        <Route path="/menu" element={<RequireAuth><MenuEditor /></RequireAuth>} />
-      </Routes>
-
-    </>
-  );
+  if (!showCmdK) return null;
+  return <CommandPalette onClose={() => setShowCmdK(false)} />;
 }
 
-function App() {
+// Standalone-only header: hidden on /login (relative to the active base).
+function StandaloneHeader() {
+  const location = useLocation();
+  const base = useBase();
+  const isLoginPage = location.pathname === withBase(base, '/login');
+  if (isLoginPage) return null;
+  return <Header />;
+}
+
+/**
+ * StudioRoutes — the named, relativized routes fragment.
+ *
+ * - No <BrowserRouter>: nested under <Route path="/studio/*"> in combined mode,
+ *   or under root standalone.
+ * - When `header` is true (standalone), renders the conditional <Header/>
+ *   (hidden on /login). apps/all omits it and renders one unified header.
+ * - Includes the ⌘K CommandPalette in both modes.
+ */
+export function StudioRoutes({ header = false }: { header?: boolean }) {
   useEffect(() => {
     getStats().then(stats => {
       if (stats.vault_repo) setVaultRepo(stats.vault_repo);
@@ -105,14 +92,54 @@ function App() {
   }, []);
 
   return (
-    <BrowserRouter>
-      <BackendGate>
-        <AuthProvider>
-          <AppContent />
-        </AuthProvider>
-      </BackendGate>
-    </BrowserRouter>
+    <BackendGate>
+      <AuthProvider>
+        {header && <StandaloneHeader />}
+        <CommandPaletteHotkey />
+        <Routes>
+          <Route path="login" element={<Login />} />
+          <Route index element={<RequireAuth><Overview /></RequireAuth>} />
+          <Route path="feed" element={<RequireAuth><Feed /></RequireAuth>} />
+          <Route path="doc/:id" element={<RequireAuth><DocDetail /></RequireAuth>} />
+          <Route path="search" element={<RequireAuth><Search /></RequireAuth>} />
+          <Route path="playground" element={<RequireAuth><Playground /></RequireAuth>} />
+          <Route path="compare" element={<RequireAuth><Compare /></RequireAuth>} />
+          <Route path="map" element={<RequireAuth><Map /></RequireAuth>} />
+          <Route path="graph" element={<GraphRedirect />} />
+          <Route path="graph3d" element={<GraphRedirect />} />
+          <Route path="handoff" element={<RequireAuth><Handoff /></RequireAuth>} />
+          <Route path="activity" element={<RequireAuth><Activity /></RequireAuth>} />
+          <Route path="evolution" element={<RequireAuth><Evolution /></RequireAuth>} />
+          <Route path="traces" element={<RequireAuth><Traces /></RequireAuth>} />
+          <Route path="traces/:id" element={<RequireAuth><Traces /></RequireAuth>} />
+          <Route path="superseded" element={<RequireAuth><Superseded /></RequireAuth>} />
+          <Route path="pulse" element={<RequireAuth><Pulse /></RequireAuth>} />
+          <Route path="sessions" element={<RequireAuth><Sessions /></RequireAuth>} />
+          <Route path="sessions/:id" element={<RequireAuth><Sessions /></RequireAuth>} />
+          <Route path="canvas" element={<RequireAuth><Canvas /></RequireAuth>} />
+          <Route path="planets" element={<RequireAuth><Planets /></RequireAuth>} />
+          <Route path="plugins" element={<RequireAuth><Plugins /></RequireAuth>} />
+          <Route path="schedule" element={<RequireAuth><Schedule /></RequireAuth>} />
+          <Route path="settings" element={<RequireAuth><Settings /></RequireAuth>} />
+          <Route path="menu" element={<RequireAuth><MenuEditor /></RequireAuth>} />
+        </Routes>
+      </AuthProvider>
+    </BackendGate>
   );
 }
 
-export default App;
+// Base-aware redirect for legacy /graph and /graph3d -> /map.
+function GraphRedirect() {
+  const base = useBase();
+  return <Navigate to={withBase(base, '/map')} replace />;
+}
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <BasePathProvider value="">
+        <StudioRoutes header />
+      </BasePathProvider>
+    </BrowserRouter>
+  );
+}

--- a/apps/studio/src/components/CommandPalette.tsx
+++ b/apps/studio/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect, memo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavTo } from '@ui-oracle/shared-ui';
 import { search } from '../api/oracle';
 import type { Document } from '../api/oracle';
 import styles from './CommandPalette.module.css';
@@ -39,7 +39,7 @@ export const CommandPalette = memo(function CommandPalette({ onClose }: CommandP
   const inputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
-  const navigate = useNavigate();
+  const navigate = useNavTo();
 
   useEffect(() => {
     inputRef.current?.focus();

--- a/apps/studio/src/components/Header.tsx
+++ b/apps/studio/src/components/Header.tsx
@@ -1,6 +1,5 @@
-import { Link } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { AppHeader } from '@ui-oracle/shared-ui';
+import { AppHeader, AppLink as Link } from '@ui-oracle/shared-ui';
 import { useAuth } from '../contexts/AuthContext';
 import { API_BASE, ping } from '../api/oracle';
 import menuConfig from '../../menu.json';

--- a/apps/studio/src/components/LogCard.tsx
+++ b/apps/studio/src/components/LogCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { AppLink as Link } from '@ui-oracle/shared-ui';
 import type { Document } from '../api/oracle';
 import { getDocDisplayInfo } from '../utils/docDisplay';
 import styles from './LogCard.module.css';

--- a/apps/studio/src/components/SidebarLayout.tsx
+++ b/apps/studio/src/components/SidebarLayout.tsx
@@ -1,4 +1,5 @@
-import { Link, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { AppLink as Link } from '@ui-oracle/shared-ui';
 
 const DEFAULT_TYPES = [
   { key: 'all', label: 'All' },

--- a/apps/studio/src/pages/Activity.tsx
+++ b/apps/studio/src/pages/Activity.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { useSearchParams, Link } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
+import { AppLink as Link } from '@ui-oracle/shared-ui';
 import { getDashboardSummary, getDashboardActivity, getDashboardGrowth } from '../api/oracle';
 import type { DashboardSummary, DashboardActivity, DashboardGrowth } from '../api/oracle';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';

--- a/apps/studio/src/pages/Compare.tsx
+++ b/apps/studio/src/pages/Compare.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
+import { useNavTo } from '@ui-oracle/shared-ui';
 import { search } from '../api/oracle';
 import type { Document } from '../api/oracle';
 import { Spinner } from '../components/ui/Spinner';
@@ -45,7 +46,7 @@ const TYPE_BADGE_STYLES: Record<string, { bg: string; color: string }> = {
 };
 
 export function Compare() {
-  const navigate = useNavigate();
+  const navigate = useNavTo();
   const [searchParams, setSearchParams] = useSearchParams();
   const [query, setQuery] = useState(searchParams.get('q') || '');
   const [mode, setMode] = useState<'vector' | 'hybrid' | 'fts'>(

--- a/apps/studio/src/pages/DocDetail.tsx
+++ b/apps/studio/src/pages/DocDetail.tsx
@@ -1,4 +1,5 @@
-import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
+import { AppLink as Link, useNavTo } from '@ui-oracle/shared-ui';
 import { useState, useEffect, useCallback } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -17,7 +18,7 @@ interface LocationState {
 
 export function DocDetail() {
   const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
+  const navigate = useNavTo();
   const location = useLocation();
   const [doc, setDoc] = useState<Document | null>(null);
   const [fullContent, setFullContent] = useState<string | null>(null);

--- a/apps/studio/src/pages/Feed.tsx
+++ b/apps/studio/src/pages/Feed.tsx
@@ -1,12 +1,26 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useBase } from '@ui-oracle/shared-ui';
 
 const FEED_ORIGIN = 'https://feed.buildwithoracle.com';
 
 export function Feed() {
+  const base = useBase();
+  // Deliberate raw (non-base-prefixed) navigate: in the combined bundle the
+  // feed app is mounted at the TOP-LEVEL /feed, not under studio's /studio prefix.
+  const navigate = useNavigate();
+
   useEffect(() => {
+    // Combined bundle: jump to the top-level /feed section (sibling app).
+    if (base) {
+      navigate('/feed', { replace: true });
+      return;
+    }
+    // Standalone: hop to the feed subdomain.
     const qs = typeof window !== 'undefined' ? window.location.search : '';
     window.location.replace(`${FEED_ORIGIN}/${qs}`);
-  }, []);
+  }, [base, navigate]);
+
   return (
     <div className="max-w-[1300px] mx-auto py-10 px-6 text-text-secondary">
       <p className="text-sm">Redirecting to <a className="text-accent underline" href={FEED_ORIGIN}>{FEED_ORIGIN}</a>…</p>

--- a/apps/studio/src/pages/Graph3D.tsx
+++ b/apps/studio/src/pages/Graph3D.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavTo } from '@ui-oracle/shared-ui';
 import * as THREE from 'three';
 import { getGraph, getFile } from '../api/oracle';
 import { useHandTracking } from '../hooks/useHandTracking';
@@ -146,7 +146,7 @@ export function Graph3D() {
   const [hoveredNode, setHoveredNode] = useState<Node | null>(null);
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);  // Clicked/locked node
   const [showHud, setShowHud] = useState(true);
-  const navigate = useNavigate();
+  const navigate = useNavTo();
 
   // File viewer state
   const [fileContent, setFileContent] = useState<string | null>(null);

--- a/apps/studio/src/pages/Login.tsx
+++ b/apps/studio/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavTo } from '@ui-oracle/shared-ui';
 import { useAuth } from '../contexts/AuthContext';
 
 export function Login() {
@@ -7,7 +7,7 @@ export function Login() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const { login } = useAuth();
-  const navigate = useNavigate();
+  const navigate = useNavTo();
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/apps/studio/src/pages/Map.tsx
+++ b/apps/studio/src/pages/Map.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavTo } from '@ui-oracle/shared-ui';
 import * as THREE from 'three';
 import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
@@ -94,7 +94,7 @@ interface GlobeData {
 }
 
 export function Map() {
-  const navigate = useNavigate();
+  const navigate = useNavTo();
   const containerRef = useRef<HTMLDivElement>(null);
   const [globes, setGlobes] = useState<GlobeData[]>([]);
   const [stats, setStats] = useState<Stats | null>(null);

--- a/apps/studio/src/pages/Overview.tsx
+++ b/apps/studio/src/pages/Overview.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { PageShell } from '@ui-oracle/shared-ui';
+import { PageShell, AppLink as Link } from '@ui-oracle/shared-ui';
 import { getStats, reflect, stripProjectPrefix } from '../api/oracle';
 import type { Document, Stats } from '../api/oracle';
 

--- a/apps/studio/src/pages/Planets.tsx
+++ b/apps/studio/src/pages/Planets.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavTo } from '@ui-oracle/shared-ui';
 import { usePlanetsData } from '../hooks/usePlanetsData';
 import { usePlanetsSearch } from '../hooks/usePlanetsSearch';
 import { PlanetsCanvas } from '../components/planets/PlanetsCanvas';
@@ -10,7 +10,7 @@ import { NebulaLegend } from '../components/planets/NebulaLegend';
 import { TYPE_COLORS } from '../lib/type-colors';
 
 export function Planets() {
-  const navigate = useNavigate();
+  const navigate = useNavTo();
   const data = usePlanetsData();
   const search = usePlanetsSearch();
   const [visibleTypes, setVisibleTypes] = useState<Set<string>>(() => new Set(Object.keys(TYPE_COLORS)));

--- a/apps/studio/src/pages/Playground.tsx
+++ b/apps/studio/src/pages/Playground.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { AppLink as Link } from '@ui-oracle/shared-ui';
 import { search } from '../api/oracle';
 import type { Document } from '../api/oracle';
 

--- a/apps/studio/src/pages/Schedule.tsx
+++ b/apps/studio/src/pages/Schedule.tsx
@@ -1,13 +1,25 @@
 import { useEffect } from 'react';
-import { hostLabel } from '@ui-oracle/shared-ui';
+import { useNavigate } from 'react-router-dom';
+import { hostLabel, useBase } from '@ui-oracle/shared-ui';
 
 const SCHEDULE_ORIGIN = 'https://schedule.buildwithoracle.com';
 
 export function Schedule() {
+  const base = useBase();
+  // Deliberate raw (non-base-prefixed) navigate: in the combined bundle the
+  // schedule app is mounted at the TOP-LEVEL /schedule, not under studio's prefix.
+  const navigate = useNavigate();
+
   useEffect(() => {
+    // Combined bundle: jump to the top-level /schedule section (sibling app).
+    if (base) {
+      navigate('/schedule', { replace: true });
+      return;
+    }
+    // Standalone: hop to the schedule subdomain.
     const currentHost = hostLabel().replace(' (default)', '');
     window.location.replace(`${SCHEDULE_ORIGIN}/?host=${encodeURIComponent(currentHost)}`);
-  }, []);
+  }, [base, navigate]);
 
   return (
     <div className="min-h-[60vh] flex items-center justify-center text-text-muted text-sm">

--- a/apps/studio/src/pages/Sessions.tsx
+++ b/apps/studio/src/pages/Sessions.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Link, useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { AppLink as Link, useNavTo } from '@ui-oracle/shared-ui';
 import { API_BASE } from '../api/oracle';
 import { Spinner } from '../components/ui/Spinner';
 
@@ -37,7 +38,7 @@ function formatTime(ts: string | number | undefined): string {
 
 export function Sessions() {
   const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
+  const navigate = useNavTo();
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [context, setContext] = useState<SessionContext | null>(null);
   const [loading, setLoading] = useState(true);

--- a/apps/studio/src/pages/Traces.tsx
+++ b/apps/studio/src/pages/Traces.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useNavTo } from '@ui-oracle/shared-ui';
 import { SidebarLayout, TOOLS_NAV } from '../components/SidebarLayout';
 import { getDocDisplayInfo } from '../utils/docDisplay';
 import { Spinner } from '../components/ui/Spinner';
@@ -58,7 +59,7 @@ const TRACE_FILTERS = [
 
 export function Traces() {
   const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
+  const navigate = useNavTo();
   const [traces, setTraces] = useState<TraceSummary[]>([]);
   const [selectedTrace, setSelectedTrace] = useState<TraceDetail | null>(null);
   const [loading, setLoading] = useState(true);

--- a/apps/vector/src/App.tsx
+++ b/apps/vector/src/App.tsx
@@ -1,22 +1,36 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BasePathProvider } from '@ui-oracle/shared-ui';
 import Playground from './pages/Playground';
 import Compare from './pages/Compare';
 import { Header } from './components/Header';
 import { BackendGate } from './components/BackendGate';
 
+/**
+ * Named routes fragment for combinable mode (no <BrowserRouter>, no <Header/>).
+ * Routes are relativized so this can nest under <Route path="/vector/*"> in
+ * apps/all, and under root when mounted standalone.
+ */
+export function VectorRoutes() {
+  return (
+    <BackendGate>
+      {({ backendLive }) => (
+        <Routes>
+          <Route path="compare" element={<Compare />} />
+          <Route index element={<Playground backendLive={backendLive} />} />
+          <Route path="*" element={<Playground backendLive={backendLive} />} />
+        </Routes>
+      )}
+    </BackendGate>
+  );
+}
+
 export default function App() {
   return (
     <BrowserRouter>
-      <Header />
-      <BackendGate>
-        {({ backendLive }) => (
-          <Routes>
-            <Route path="/compare" element={<Compare />} />
-            <Route path="/" element={<Playground backendLive={backendLive} />} />
-            <Route path="*" element={<Playground backendLive={backendLive} />} />
-          </Routes>
-        )}
-      </BackendGate>
+      <BasePathProvider value="">
+        <Header />
+        <VectorRoutes />
+      </BasePathProvider>
     </BrowserRouter>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,37 @@
     "": {
       "name": "ui-oracle",
     },
+    "apps/all": {
+      "name": "all-oracle-studio",
+      "version": "0.1.0",
+      "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@types/three": "^0.182.0",
+        "@ui-oracle/shared-ui": "workspace:*",
+        "knowledge-map-3d": "github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D",
+        "ml5": "1",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "react-markdown": "^10.1.0",
+        "react-router-dom": "^7.11.0",
+        "recharts": "^3.6.0",
+        "remark-gfm": "^4.0.1",
+        "three": "^0.182.0",
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.2.1",
+        "@types/bun": "^1.3.12",
+        "@types/node": "^24.10.1",
+        "@types/react": "^19.2.5",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.1.1",
+        "tailwindcss": "^4.2.1",
+        "typescript": "~5.9.3",
+        "vite": "^7.2.4",
+      },
+    },
     "apps/canvas": {
       "name": "canvas-oracle-studio",
       "version": "0.1.0",
@@ -555,7 +586,7 @@
 
     "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
 
-    "@types/three": ["@types/three@0.184.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA=="],
+    "@types/three": ["@types/three@0.182.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.22.0" } }, "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -596,6 +627,8 @@
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "all-oracle-studio": ["all-oracle-studio@workspace:apps/all"],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -1021,7 +1054,7 @@
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
-    "meshoptimizer": ["meshoptimizer@1.1.1", "", {}, "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g=="],
+    "meshoptimizer": ["meshoptimizer@0.22.0", "", {}, "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -1243,7 +1276,7 @@
 
     "tapable": ["tapable@2.3.2", "", {}, "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA=="],
 
-    "three": ["three@0.184.0", "", {}, "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg=="],
+    "three": ["three@0.182.0", "", {}, "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ=="],
 
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
@@ -1441,6 +1474,12 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
+    "canvas-oracle-studio/@types/three": ["@types/three@0.184.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA=="],
+
+    "canvas-oracle-studio/knowledge-map-3d": ["knowledge-map-3d@github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D#4dfd12d", { "peerDependencies": { "react": ">=18", "react-dom": ">=18", "three": ">=0.150.0" } }, "Bombbaza-Multi-Planet-System-Knowledge-Map-3D-4dfd12d", "sha512-ddXFX0qW9mEd+3JaixN8wwGwsvaFKz0foCXz+ioPQug+s84lSfZGYdJUfyB+rSnpCcnf275WQhBOSR9JYxUIlg=="],
+
+    "canvas-oracle-studio/three": ["three@0.184.0", "", {}, "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg=="],
+
     "d3-dsv/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "d3-force/d3-timer": ["d3-timer@2.0.0", "", {}, "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="],
@@ -1457,9 +1496,7 @@
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
-    "oracle-studio/@types/three": ["@types/three@0.182.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.22.0" } }, "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q=="],
-
-    "oracle-studio/three": ["three@0.182.0", "", {}, "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ=="],
+    "oracle-studio/knowledge-map-3d": ["knowledge-map-3d@github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D#4dfd12d", { "peerDependencies": { "react": ">=18", "react-dom": ">=18", "three": ">=0.150.0" } }, "Bombbaza-Multi-Planet-System-Knowledge-Map-3D-4dfd12d", "sha512-ddXFX0qW9mEd+3JaixN8wwGwsvaFKz0foCXz+ioPQug+s84lSfZGYdJUfyB+rSnpCcnf275WQhBOSR9JYxUIlg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
@@ -1581,11 +1618,11 @@
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
+    "canvas-oracle-studio/@types/three/meshoptimizer": ["meshoptimizer@1.1.1", "", {}, "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g=="],
+
     "d3-geo-projection/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "d3-geo/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
-
-    "oracle-studio/@types/three/meshoptimizer": ["meshoptimizer@0.22.0", "", {}, "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg=="],
 
     "vega-crossfilter/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dev:forum": "bun --cwd apps/forum run dev",
     "dev:indexer": "bun --cwd apps/indexer run dev",
     "dev:hub": "bun --cwd apps/hub run dev",
+    "dev:all": "bun --cwd apps/all run dev",
     "build:studio": "bun --cwd apps/studio run build",
     "build:vector": "bun --cwd apps/vector run build",
     "build:canvas": "bun --cwd apps/canvas run build",
@@ -29,6 +30,7 @@
     "build:indexer": "bun --cwd apps/indexer run build",
     "build:hub": "bun --cwd apps/hub run build",
     "build:all": "bun run build:studio && bun run build:vector && bun run build:canvas && bun run build:schedule && bun run build:feed && bun run build:forum && bun run build:indexer && bun run build:hub",
+    "build:all-app": "bun --cwd apps/all run build",
     "preview:studio": "bun --cwd apps/studio run preview",
     "preview:vector": "bun --cwd apps/vector run preview",
     "preview:canvas": "bun --cwd apps/canvas run preview",
@@ -45,6 +47,7 @@
     "deploy:indexer": "bun --cwd apps/indexer run deploy",
     "deploy:hub": "bun --cwd apps/hub run deploy",
     "deploy:all": "bun run deploy:studio && bun run deploy:vector && bun run deploy:canvas && bun run deploy:schedule && bun run deploy:feed && bun run deploy:forum && bun run deploy:indexer && bun run deploy:hub",
+    "deploy:all-app": "bun --cwd apps/all run deploy",
     "sync:menu:gist": "bun run scripts/sync-menu.ts --gist https://gist.github.com/nazt/741e431a81ff32afb509cade18408054",
     "sync:menu:api": "bun run scripts/sync-menu.ts --api http://localhost:47778/api/menu",
     "sync:menu:reset": "bun run scripts/sync-menu.ts --reset"

--- a/packages/shared-ui/src/base-path.tsx
+++ b/packages/shared-ui/src/base-path.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext } from 'react';
+import { Link, useNavigate, type LinkProps, type NavigateOptions } from 'react-router-dom';
+
+const BaseCtx = createContext<string>('');
+export const BasePathProvider = BaseCtx.Provider;
+export function useBase(): string { return useContext(BaseCtx); }
+
+/** Prefix a leading-slash in-app path with the active base. Identity when base==='' (standalone). */
+export function withBase(base: string, to: string): string {
+  if (!base || !to.startsWith('/')) return to;
+  return base + to;
+}
+
+/** Drop-in for <Link to="/abs">. Relative/hash/external 'to' pass through unchanged. */
+export function AppLink({ to, ...rest }: LinkProps) {
+  const base = useBase();
+  return <Link to={typeof to === 'string' ? withBase(base, to) : to} {...rest} />;
+}
+
+/** Drop-in for useNavigate(); base-prefixes string targets, passes numbers through. */
+export function useNavTo() {
+  const base = useBase();
+  const navigate = useNavigate();
+  return (to: string | number, opts?: NavigateOptions) =>
+    typeof to === 'number' ? navigate(to) : navigate(withBase(base, to), opts);
+}

--- a/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/shared-ui/src/components/AppHeader/AppHeader.tsx
@@ -102,6 +102,11 @@ interface AppHeaderProps {
   hideToolsDropdown?: boolean;
   /** Per-app label ordering for main/tools. Unknown labels are ignored. */
   menuConfig?: MenuConfig;
+  /** Combined single-origin bundle mode. Opt-in; default false = current behavior. */
+  combinedMode?: boolean;
+  /** In-app href resolver for combined bundles. When provided, nav renders an
+   *  in-app <Link> to inAppHref(item) instead of <Link to={item.path}>. Opt-in. */
+  inAppHref?: (item: NavItem) => string;
 }
 
 // Unified cross-origin resolver — preserves BOTH `item.path` and `item.query`
@@ -156,6 +161,8 @@ export function AppHeader({
   crossOriginHref = defaultCrossOriginHref,
   hideToolsDropdown = false,
   menuConfig,
+  combinedMode = false,
+  inAppHref,
 }: AppHeaderProps) {
   const { nav, loaded } = useMenu(fallbackNav, { skipFetch: BAKED_NAV !== null });
   const reorderedNav = useMemo(() => reorderNavSet(nav, menuConfig), [nav, menuConfig]);
@@ -195,11 +202,21 @@ export function AppHeader({
           loaded ? 'opacity-100' : 'opacity-0'
         }`}
       >
-        <MainNav items={reorderedNav.main} crossOriginHref={crossOriginHref} />
+        <MainNav
+          items={reorderedNav.main}
+          crossOriginHref={crossOriginHref}
+          combinedMode={combinedMode}
+          inAppHref={inAppHref}
+        />
         {!hideToolsDropdown && reorderedNav.tools.length > 0 && (
           <>
             <span className="w-px h-4 bg-border mx-2" />
-            <ToolsDropdown items={reorderedNav.tools} crossOriginHref={crossOriginHref} />
+            <ToolsDropdown
+              items={reorderedNav.tools}
+              crossOriginHref={crossOriginHref}
+              combinedMode={combinedMode}
+              inAppHref={inAppHref}
+            />
           </>
         )}
       </nav>

--- a/packages/shared-ui/src/components/AppHeader/MainNav.tsx
+++ b/packages/shared-ui/src/components/AppHeader/MainNav.tsx
@@ -6,6 +6,11 @@ import { NavDisclosure } from './NavDisclosure';
 interface MainNavProps {
   items: NavItem[];
   crossOriginHref: CrossOriginResolver;
+  /** Combined single-origin bundle mode. Opt-in; default false. */
+  combinedMode?: boolean;
+  /** In-app href resolver for combined bundles. When provided, the in-app
+   *  <Link> targets inAppHref(item) instead of item.path. Opt-in. */
+  inAppHref?: (item: NavItem) => string;
 }
 
 /**
@@ -13,8 +18,11 @@ interface MainNavProps {
  * based on `crossOriginHref(item)`. Items with `children` render a disclosure
  * panel (hover desktop, tap mobile). Fully host-agnostic.
  */
-export function MainNav({ items, crossOriginHref }: MainNavProps) {
+export function MainNav({ items, crossOriginHref, combinedMode = false, inAppHref }: MainNavProps) {
   const location = useLocation();
+
+  // In combined single-origin bundles, resolve in-app targets via inAppHref.
+  const inApp = combinedMode && inAppHref ? inAppHref : undefined;
 
   return (
     <>
@@ -25,11 +33,15 @@ export function MainNav({ items, crossOriginHref }: MainNavProps) {
               key={item.path + ':' + item.label}
               item={item}
               crossOriginHref={crossOriginHref}
+              combinedMode={combinedMode}
+              inAppHref={inAppHref}
             />
           );
         }
         const href = crossOriginHref(item);
-        const active = isActiveNav(location, item);
+        const active = inApp
+          ? isActiveNav(location, item, { ignoreHostGate: true })
+          : isActiveNav(location, item);
         const cls = `px-2.5 py-1.5 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
           active
             ? 'bg-accent/15 text-accent font-semibold border border-accent/20'
@@ -42,8 +54,9 @@ export function MainNav({ items, crossOriginHref }: MainNavProps) {
             </a>
           );
         }
+        const to = inApp ? inApp(item) : item.path;
         return (
-          <Link key={item.path} to={item.path} className={cls} aria-current={active ? 'page' : undefined}>
+          <Link key={item.path} to={to} className={cls} aria-current={active ? 'page' : undefined}>
             {item.label}
           </Link>
         );

--- a/packages/shared-ui/src/components/AppHeader/NavDisclosure.tsx
+++ b/packages/shared-ui/src/components/AppHeader/NavDisclosure.tsx
@@ -6,6 +6,11 @@ import { isActiveNav } from './nav-types';
 interface NavDisclosureProps {
   item: NavItem;
   crossOriginHref: CrossOriginResolver;
+  /** Combined single-origin bundle mode. Opt-in; default false. */
+  combinedMode?: boolean;
+  /** In-app href resolver for combined bundles. When provided, in-app
+   *  <Link>s target inAppHref(item) instead of item.path. Opt-in. */
+  inAppHref?: (item: NavItem) => string;
 }
 
 /**
@@ -14,10 +19,13 @@ interface NavDisclosureProps {
  * itself navigates to `item.path` (or its cross-origin href) so a Canvas
  * parent with `studio` lands at the studio root.
  */
-export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
+export function NavDisclosure({ item, crossOriginHref, combinedMode = false, inAppHref }: NavDisclosureProps) {
   const location = useLocation();
   const [open, setOpen] = useState(false);
   const [isCoarse, setIsCoarse] = useState(false);
+
+  // In combined single-origin bundles, resolve in-app targets via inAppHref.
+  const inApp = combinedMode && inAppHref ? inAppHref : undefined;
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.matchMedia) return;
@@ -31,9 +39,13 @@ export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
   const children = item.children ?? [];
   const parentHref = crossOriginHref(item);
   const hasRealPath = item.path && item.path !== '#';
-  const parentActive = isActiveNav(location, item);
+  const parentActive = inApp
+    ? isActiveNav(location, item, { ignoreHostGate: true })
+    : isActiveNav(location, item);
   const anyActive = parentActive
-    || children.some((c) => isActiveNav(location, c));
+    || children.some((c) =>
+      inApp ? isActiveNav(location, c, { ignoreHostGate: true }) : isActiveNav(location, c),
+    );
 
   const labelClass = `px-2.5 py-1.5 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
     anyActive
@@ -61,7 +73,7 @@ export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
       );
     }
     return (
-      <Link to={item.path} className={labelClass} aria-current={parentActive ? 'page' : undefined}>
+      <Link to={inApp ? inApp(item) : item.path} className={labelClass} aria-current={parentActive ? 'page' : undefined}>
         {item.label} <span aria-hidden="true">▸</span>
       </Link>
     );
@@ -101,7 +113,9 @@ export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
           >
             {children.map((child) => {
               const href = crossOriginHref(child);
-              const childActive = isActiveNav(location, child);
+              const childActive = inApp
+                ? isActiveNav(location, child, { ignoreHostGate: true })
+                : isActiveNav(location, child);
               const childClass = `block px-3 py-2 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
                 childActive
                   ? 'bg-accent/15 text-accent font-semibold'
@@ -124,7 +138,7 @@ export function NavDisclosure({ item, crossOriginHref }: NavDisclosureProps) {
               return (
                 <Link
                   key={child.path}
-                  to={child.path}
+                  to={inApp ? inApp(child) : child.path}
                   className={childClass}
                   onClick={() => setOpen(false)}
                   role="menuitem"

--- a/packages/shared-ui/src/components/AppHeader/ToolsDropdown.tsx
+++ b/packages/shared-ui/src/components/AppHeader/ToolsDropdown.tsx
@@ -7,17 +7,27 @@ interface ToolsDropdownProps {
   items: NavItem[];
   crossOriginHref: CrossOriginResolver;
   label?: string;
+  /** Combined single-origin bundle mode. Opt-in; default false. */
+  combinedMode?: boolean;
+  /** In-app href resolver for combined bundles. When provided, the in-app
+   *  <Link> targets inAppHref(item) instead of item.path. Opt-in. */
+  inAppHref?: (item: NavItem) => string;
 }
 
 /**
  * Hover-triggered "Tools ▾" dropdown. Renders internal or cross-origin links
  * via `crossOriginHref(item)`.
  */
-export function ToolsDropdown({ items, crossOriginHref, label = 'Tools ▾' }: ToolsDropdownProps) {
+export function ToolsDropdown({ items, crossOriginHref, label = 'Tools ▾', combinedMode = false, inAppHref }: ToolsDropdownProps) {
   const location = useLocation();
   const [open, setOpen] = useState(false);
 
-  const anyActive = items.some((t) => isActiveNav(location, t));
+  // In combined single-origin bundles, resolve in-app targets via inAppHref.
+  const inApp = combinedMode && inAppHref ? inAppHref : undefined;
+
+  const anyActive = items.some((t) =>
+    inApp ? isActiveNav(location, t, { ignoreHostGate: true }) : isActiveNav(location, t),
+  );
 
   return (
     <div
@@ -47,7 +57,9 @@ export function ToolsDropdown({ items, crossOriginHref, label = 'Tools ▾' }: T
       >
         {items.map((item) => {
           const href = crossOriginHref(item);
-          const active = isActiveNav(location, item);
+          const active = inApp
+            ? isActiveNav(location, item, { ignoreHostGate: true })
+            : isActiveNav(location, item);
           const cls = `block px-3 py-2 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
             active
               ? 'bg-accent/15 text-accent font-semibold'
@@ -60,8 +72,9 @@ export function ToolsDropdown({ items, crossOriginHref, label = 'Tools ▾' }: T
               </a>
             );
           }
+          const to = inApp ? inApp(item) : item.path;
           return (
-            <Link key={item.path} to={item.path} className={cls} onClick={() => setOpen(false)} role="menuitem" aria-current={active ? 'page' : undefined}>
+            <Link key={item.path} to={to} className={cls} onClick={() => setOpen(false)} role="menuitem" aria-current={active ? 'page' : undefined}>
               {item.label}
             </Link>
           );

--- a/packages/shared-ui/src/components/AppHeader/nav-types.ts
+++ b/packages/shared-ui/src/components/AppHeader/nav-types.ts
@@ -39,15 +39,19 @@ export function isActivePath(location: Location, path: string): boolean {
 export function isActiveNav(
   location: Location,
   item: { path: string; studio?: string; query?: Record<string, string> },
+  opts?: { ignoreHostGate?: boolean; base?: string },
 ): boolean {
-  if (item.studio) {
+  const ignoreHostGate = opts?.ignoreHostGate === true;
+  if (item.studio && !ignoreHostGate) {
     if (typeof window === 'undefined') return false;
     const hostMatch = window.location.hostname === item.studio
       || window.location.hostname.endsWith('.' + item.studio);
     if (!hostMatch) return false;
   }
 
-  const itemPath = item.path.split('?')[0];
+  const itemPath = ignoreHostGate
+    ? (opts?.base ?? '') + item.path.split('?')[0]
+    : item.path.split('?')[0];
   if (location.pathname !== itemPath) return false;
 
   if (item.query) {

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -31,6 +31,9 @@ export { SubNav } from './components/SubNav';
 export type { SubNavItem } from './components/SubNav';
 export { PageShell } from './components/PageShell';
 
+// Base-path routing (combined single-origin bundle; identity when standalone)
+export { BasePathProvider, useBase, withBase, AppLink, useNavTo } from './base-path';
+
 // Tokens
 export { LAYOUT, CHIP_COLORS } from './tokens';
 


### PR DESCRIPTION
## What

New **`apps/all`** (worker `all-oracle-studio`, **live at app.buildwithoracle.com**): a single Vite bundle that mounts every app under a path — `/studio`, `/vector`, `/canvas`, `/feed`, `/forum`, `/schedule`, `/indexer` — with a shared header and instant in-app navigation. **No iframes.** Each app stays independently deployable to its own subdomain — the split is preserved.

This supersedes the iframe `apps/hub` for the `app.buildwithoracle.com` slot (hub left in tree; remove in a follow-up if desired).

## Dual-mode mechanism (the "still splittable" trick)

- **`shared-ui/base-path.tsx`** — `BasePathProvider` / `useBase` / `withBase` / `AppLink` / `useNavTo`. A **runtime base context** means the *same compiled component* works at `/` standalone (base `''`) and under `/studio` combined. Links route through base-aware `AppLink`/`useNavTo` that are the **identity function when base is `''`** — so standalone behavior is byte-for-byte unchanged.
- **`AppHeader`** gains opt-in `combinedMode`/`inAppHref` props + an `isActiveNav` host-gate opt-out for same-origin path nav. All additive.
- **Each app** exports an `XRoutes` fragment (relative routes, no `BrowserRouter`, no page header); its standalone `App` keeps its own `BrowserRouter` + `value=""`. In-app `Link`/`useNavigate` aliased to the shared-ui base-aware equivalents.
- **`apps/all`** — one `BrowserRouter` mounts the 7 fragments under `/<app>/*`, a merged single stylesheet (12 `@theme` tokens once + canvas keyframes), unified `CombinedHeader`, `/` → `/studio`.

## Bug fixed during the build

A **combined-only infinite loop**: studio's Feed/Schedule redirect stubs resolved to `/studio/feed` (their own route) → CPU-pegging loop. Fixed to jump to the **top-level** `/feed`,`/schedule` sections via raw `useNavigate`. Caught and fixed before deploy.

## Verification

- ✅ All 7 standalone builds green + combined build green (the combined `tsconfig` type-checks all 7 apps' src)
- ✅ Grep alias-invariant clean — no `Link`/`useNavigate` from `react-router-dom` leaking outside standalone wrappers (the 2 in studio Feed/Schedule are deliberate top-level redirects, documented)
- ✅ Deployed & verified: `app.buildwithoracle.com` → `HTTP/2 200`, `/studio` deep route → 200

## Note on PR #92

This branch is based on the indexer-build fix, so it **includes the `fix(indexer): add missing vite-env.d.ts` commit** (PR #92) — `apps/all` won't type-check without it. Merge this and close #92, or merge #92 first (this rebases cleanly).

## Follow-ups (non-blocking)
- Combined JS bundle ~2.6 MB (studio's three.js/ml5/recharts) — lazy-load per section later.
- Optional: rename worker `all-oracle-studio` → `arra-oracle` to match the brand.
- Remove the now-superseded iframe `apps/hub`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)