### PR TITLE
feat(all): studio-at-root, serve at studio.*, always-localhost, local bunx + no-cache HTML

### DIFF
--- a/apps/all/bin/serve.ts
+++ b/apps/all/bin/serve.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env bun
+/**
+ * ARRA 🔮Racle — serve the combined Oracle hub locally.
+ *
+ * One bundle, every app under one origin: studio at root, satellites at
+ * /vector, /feed, /canvas, /forum, /schedule, /indexer.
+ *
+ * Usage:
+ *   bunx all-oracle-studio                          # default: port 3000, API at localhost:47778
+ *   bunx all-oracle-studio --port 4000              # custom port
+ *   bunx all-oracle-studio --api http://host:47778  # custom backend API URL
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, extname } from 'path';
+
+const args = process.argv.slice(2);
+
+function getArg(flag: string, fallback: string): string {
+  const idx = args.indexOf(flag);
+  return idx !== -1 && args[idx + 1] ? args[idx + 1] : fallback;
+}
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`
+ARRA 🔮Racle — combined Oracle hub (studio + vector + canvas + feed + forum + schedule + indexer)
+
+Usage:
+  all-oracle-studio [options]
+
+Options:
+  --port <number>   Port to serve on (default: 3000)
+  --api  <url>      Oracle backend API URL (default: http://localhost:47778)
+  -h, --help        Show this help
+`);
+  process.exit(0);
+}
+
+const PORT = parseInt(getArg('--port', '3000'), 10);
+const API_URL = getArg('--api', 'http://localhost:47778');
+const DIST = join(import.meta.dirname, '..', 'dist');
+
+if (!existsSync(DIST)) {
+  const projectRoot = join(import.meta.dirname, '..');
+  console.log('📦 dist/ not found — building once (~10s)…');
+  const result = Bun.spawnSync(['bun', 'run', 'build'], {
+    cwd: projectRoot,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  if (result.exitCode !== 0 || !existsSync(DIST)) {
+    console.error('Error: build failed or dist/ still missing. Try `cd` into the package and run `bun run build`.');
+    process.exit(1);
+  }
+}
+
+const MIME: Record<string, string> = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+};
+
+Bun.serve({
+  port: PORT,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    // Proxy /api/* to the arra-oracle backend
+    if (url.pathname.startsWith('/api/')) {
+      const target = `${API_URL}${url.pathname}${url.search}`;
+      const headers = new Headers(req.headers);
+      headers.delete('host');
+      try {
+        return await fetch(target, {
+          method: req.method,
+          headers,
+          body: req.method !== 'GET' && req.method !== 'HEAD' ? req.body : undefined,
+          redirect: 'follow',
+        });
+      } catch {
+        return new Response(JSON.stringify({ error: 'API unreachable', target: API_URL }), {
+          status: 502,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+    }
+
+    // Serve static files
+    const filePath = join(DIST, url.pathname === '/' ? 'index.html' : url.pathname);
+    if (existsSync(filePath)) {
+      const content = readFileSync(filePath);
+      const ext = extname(filePath);
+      return new Response(content, {
+        headers: { 'content-type': MIME[ext] || 'application/octet-stream' },
+      });
+    }
+
+    // SPA fallback — every non-asset path renders the app (studio at root, satellites under their prefix)
+    const indexPath = join(DIST, 'index.html');
+    if (existsSync(indexPath)) {
+      return new Response(readFileSync(indexPath), {
+        headers: { 'content-type': 'text/html' },
+      });
+    }
+
+    return new Response('Not Found', { status: 404 });
+  },
+});
+
+console.log(`
+🔮 ARRA Oracle hub running!
+
+   Hub:       http://localhost:${PORT}
+   API proxy: ${API_URL}
+   Sections:  /  (studio) · /vector · /feed · /canvas · /forum · /schedule · /indexer
+`);

--- a/apps/all/package.json
+++ b/apps/all/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.0",
   "type": "module",
   "description": "Combined bundle — app.buildwithoracle.com",
+  "bin": {
+    "all-oracle-studio": "./bin/serve.ts"
+  },
+  "files": [
+    "bin/",
+    "dist/"
+  ],
   "engines": {
     "bun": ">=1.2.0"
   },
@@ -13,8 +20,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "serve": "bun bin/serve.ts",
     "preview": "vite preview",
-    "deploy": "bun run build && wrangler deploy"
+    "deploy": "bun run build && wrangler deploy",
+    "prepublishOnly": "bun run build"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/apps/all/src/App.tsx
+++ b/apps/all/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { BasePathProvider } from '@ui-oracle/shared-ui';
 import { CombinedHeader } from './CombinedHeader';
 
@@ -21,14 +21,7 @@ export default function App() {
     <BrowserRouter>
       <CombinedHeader />
       <Routes>
-        <Route
-          path="/studio/*"
-          element={
-            <BasePathProvider value="/studio">
-              <StudioRoutes />
-            </BasePathProvider>
-          }
-        />
+        {/* Satellites first (most specific) — each shadows any studio stub at the same path. */}
         <Route
           path="/vector/*"
           element={
@@ -77,7 +70,15 @@ export default function App() {
             </BasePathProvider>
           }
         />
-        <Route path="/" element={<Navigate to="/studio" replace />} />
+        {/* Studio mounted at the ROOT catch-all — its index route serves "/". */}
+        <Route
+          path="/*"
+          element={
+            <BasePathProvider value="">
+              <StudioRoutes />
+            </BasePathProvider>
+          }
+        />
       </Routes>
     </BrowserRouter>
   );

--- a/apps/all/src/nav-map.ts
+++ b/apps/all/src/nav-map.ts
@@ -6,7 +6,7 @@ import type { NavItem } from '@ui-oracle/shared-ui';
  * the empty base (i.e. their `path` is used verbatim).
  */
 export const SUBDOMAIN_TO_BASE: Record<string, string> = {
-  'studio.buildwithoracle.com': '/studio',
+  'studio.buildwithoracle.com': '',
   'vector.buildwithoracle.com': '/vector',
   'canvas.buildwithoracle.com': '/canvas',
   'feed.buildwithoracle.com': '/feed',
@@ -21,10 +21,10 @@ export const SUBDOMAIN_TO_BASE: Record<string, string> = {
  * `query` appended as `?k=v`.
  */
 export function inAppHref(item: NavItem): string {
-  // Items without a mapped `studio` host belong to studio (the hub that owns the
-  // shared tools/routes — Pulse, Traces, Sessions, …), so default to the /studio
-  // section rather than top-level, where those routes don't exist.
-  const base = (item.studio && SUBDOMAIN_TO_BASE[item.studio]) || '/studio';
+  // Studio is mounted at the ROOT, so studio's own tools (Pulse, Traces,
+  // Sessions, …) and items mapped to the studio host both resolve against the
+  // empty base. Satellites keep their path prefix from the map.
+  const base = item.studio ? (SUBDOMAIN_TO_BASE[item.studio] ?? '') : '';
   let href = base + item.path;
 
   if (item.query) {

--- a/apps/all/worker.ts
+++ b/apps/all/worker.ts
@@ -15,7 +15,7 @@ export default {
     if (HASHED_ASSET.test(url.pathname)) {
       headers.set("cache-control", "public, max-age=31536000, immutable");
     } else {
-      headers.set("cache-control", "public, max-age=3600, stale-while-revalidate=86400");
+      headers.set("cache-control", "no-cache");
     }
 
     return new Response(response.body, {

--- a/apps/all/wrangler.json
+++ b/apps/all/wrangler.json
@@ -8,6 +8,14 @@
     {
       "pattern": "app.buildwithoracle.com",
       "custom_domain": true
+    },
+    {
+      "pattern": "studio.buildwithoracle.com",
+      "custom_domain": true
+    },
+    {
+      "pattern": "local.buildwithoracle.com",
+      "custom_domain": true
     }
   ],
   "assets": {

--- a/apps/studio/wrangler.json
+++ b/apps/studio/wrangler.json
@@ -4,16 +4,7 @@
   "compatibility_date": "2025-06-01",
   "account_id": "a5eabdc2b11aae9bd5af46bd6a88179e",
   "workers_dev": true,
-  "routes": [
-    {
-      "pattern": "studio.buildwithoracle.com",
-      "custom_domain": true
-    },
-    {
-      "pattern": "local.buildwithoracle.com",
-      "custom_domain": true
-    }
-  ],
+  "routes": [],
   "assets": {
     "directory": "./dist",
     "binding": "ASSETS",

--- a/packages/shared-ui/src/host.ts
+++ b/packages/shared-ui/src/host.ts
@@ -41,7 +41,14 @@ if (urlHost && typeof window !== 'undefined') {
   window.location.replace(url.toString());
 }
 
-const storedHost = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+let storedHost = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+// Self-heal: a stored host pointing at a deployed public domain (e.g. a stale
+// "app.buildwithoracle.com:47778" left by an older build, or any *.workers.dev)
+// can never be a real :47778 backend — drop it and fall back to localhost.
+if (storedHost && /(?:\.buildwithoracle\.com|\.workers\.dev)/i.test(storedHost)) {
+  if (typeof window !== 'undefined') localStorage.removeItem(STORAGE_KEY);
+  storedHost = null;
+}
 const hostParam = storedHost ?? DEFAULT_HOST;
 
 export const isRemote = !!storedHost;


### PR DESCRIPTION
Five changes to the ARRA Oracle combined bundle (`apps/all`) — all deployed + verified live on `app.*` and `studio.buildwithoracle.com`.

## 1. Studio at root (no `/studio` prefix)
`app.buildwithoracle.com/` = studio overview, `/search`/`/traces`/… at root; satellites stay namespaced at `/vector`, `/feed`, `/canvas`, `/forum`, `/schedule`, `/indexer`. (`App.tsx`: satellites matched first, studio at `/*` catch-all with `value=""`; `nav-map.ts`: studio host → `""` base.) **Browser-verified**: Overview→`/`, Search→`/search`, Vector→`/vector`.

## 2. Combined bundle also serves `studio.*` + `local.*`
Moved those custom domains onto `all-oracle-studio` (`apps/all/wrangler.json`); the standalone studio worker's routes are emptied (`apps/studio/wrangler.json`) so it stops re-claiming them.

## 3. Backend host always-localhost (self-heal)
`host.ts` drops a stored host pointing at a `*.buildwithoracle.com` / `*.workers.dev` domain (never a real `:47778` backend) → falls back to `localhost:47778`. **Browser-verified**: injected `app.buildwithoracle.com:47778` → healed to `localhost:47778`, `stored host after reload: null`.

## 4. Locally runnable via bunx
`apps/all/bin/serve.ts` — a Bun static server + `/api/*` proxy → `localhost:47778` (mirrors `oracle-studio`). Wired via `package.json` `bin`/`files`/`serve`/`prepublishOnly`. **Smoke-tested** against the live backend: `bun apps/all/bin/serve.ts` → `/` 200 (ARRA 🔮Racle), `/vector` 200 (SPA fallback), `/api/stats` 200 with real JSON.
```
bun apps/all/bin/serve.ts            # serves the hub at :3000, API → localhost:47778
bun apps/all/bin/serve.ts --port 4000 --api http://host:47778
```

## 5. Fix blank-screen-on-first-reload
`apps/all/worker.ts` serves `index.html` with `cache-control: no-cache` (hashed assets stay `immutable`). Previously `max-age=3600` let a reload after a deploy serve a cached HTML referencing a now-purged JS hash → blank screen. **Verified live**: `curl -I app.buildwithoracle.com/` → `cache-control: no-cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)