### PR TITLE
chore(all): make @soul-brews-studio/arra-oracle-studio publishable to npm

### DIFF
--- a/apps/all/bin/serve.ts
+++ b/apps/all/bin/serve.ts
@@ -6,9 +6,9 @@
  * /vector, /feed, /canvas, /forum, /schedule, /indexer.
  *
  * Usage:
- *   bunx all-oracle-studio                          # default: port 3000, API at localhost:47778
- *   bunx all-oracle-studio --port 4000              # custom port
- *   bunx all-oracle-studio --api http://host:47778  # custom backend API URL
+ *   bunx @soul-brews-studio/arra-oracle-studio                          # default: port 3000, API at localhost:47778
+ *   bunx @soul-brews-studio/arra-oracle-studio --port 4000              # custom port
+ *   bunx @soul-brews-studio/arra-oracle-studio --api http://host:47778  # custom backend API URL
  */
 
 import { readFileSync, existsSync } from 'fs';
@@ -26,7 +26,7 @@ if (args.includes('--help') || args.includes('-h')) {
 ARRA 🔮Racle — combined Oracle hub (studio + vector + canvas + feed + forum + schedule + indexer)
 
 Usage:
-  all-oracle-studio [options]
+  arra-oracle-studio [options]
 
 Options:
   --port <number>   Port to serve on (default: 3000)

--- a/apps/all/package.json
+++ b/apps/all/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@soul-brews-studio/all-oracle-studio",
+  "name": "@soul-brews-studio/arra-oracle-studio",
   "version": "0.1.0",
   "type": "module",
   "description": "ARRA 🔮Racle — the combined Oracle hub (studio + vector + canvas + feed + forum + schedule + indexer) in one bundle. Run it locally with a static server + /api proxy to your local arra-oracle backend.",
@@ -11,7 +11,7 @@
     "spa"
   ],
   "bin": {
-    "all-oracle-studio": "./bin/serve.ts"
+    "arra-oracle-studio": "./bin/serve.ts"
   },
   "files": [
     "bin/",

--- a/apps/all/package.json
+++ b/apps/all/package.json
@@ -1,8 +1,15 @@
 {
-  "name": "all-oracle-studio",
+  "name": "@soul-brews-studio/all-oracle-studio",
   "version": "0.1.0",
   "type": "module",
-  "description": "Combined bundle — app.buildwithoracle.com",
+  "description": "ARRA 🔮Racle — the combined Oracle hub (studio + vector + canvas + feed + forum + schedule + indexer) in one bundle. Run it locally with a static server + /api proxy to your local arra-oracle backend.",
+  "keywords": [
+    "arra-oracle",
+    "oracle-studio",
+    "buildwithoracle",
+    "thin-client",
+    "spa"
+  ],
   "bin": {
     "all-oracle-studio": "./bin/serve.ts"
   },
@@ -12,6 +19,9 @@
   ],
   "engines": {
     "bun": ">=1.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "repository": {
     "type": "git",
@@ -25,12 +35,19 @@
     "deploy": "bun run build && wrangler deploy",
     "prepublishOnly": "bun run build"
   },
-  "dependencies": {
+  "comment:deps": "No runtime dependencies — bin/serve.ts uses only Node builtins (fs/path) + Bun.serve, and dist/ is the self-contained Vite bundle (react/three/shared-ui already inlined). Everything below is build-time only.",
+  "devDependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@tailwindcss/vite": "^4.2.1",
+    "@types/bun": "^1.3.12",
+    "@types/node": "^24.10.1",
+    "@types/react": "^19.2.5",
+    "@types/react-dom": "^19.2.3",
     "@types/three": "^0.182.0",
     "@ui-oracle/shared-ui": "workspace:*",
+    "@vitejs/plugin-react": "^5.1.1",
     "knowledge-map-3d": "github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D",
     "ml5": "1",
     "react": "^19.2.0",
@@ -39,16 +56,8 @@
     "react-router-dom": "^7.11.0",
     "recharts": "^3.6.0",
     "remark-gfm": "^4.0.1",
-    "three": "^0.182.0"
-  },
-  "devDependencies": {
-    "@tailwindcss/vite": "^4.2.1",
-    "@types/bun": "^1.3.12",
-    "@types/node": "^24.10.1",
-    "@types/react": "^19.2.5",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^5.1.1",
     "tailwindcss": "^4.2.1",
+    "three": "^0.182.0",
     "typescript": "~5.9.3",
     "vite": "^7.2.4"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -6,10 +6,10 @@
       "name": "ui-oracle",
     },
     "apps/all": {
-      "name": "@soul-brews-studio/all-oracle-studio",
+      "name": "@soul-brews-studio/arra-oracle-studio",
       "version": "0.1.0",
       "bin": {
-        "all-oracle-studio": "./bin/serve.ts",
+        "arra-oracle-studio": "./bin/serve.ts",
       },
       "devDependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -428,7 +428,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
 
-    "@soul-brews-studio/all-oracle-studio": ["@soul-brews-studio/all-oracle-studio@workspace:apps/all"],
+    "@soul-brews-studio/arra-oracle-studio": ["@soul-brews-studio/arra-oracle-studio@workspace:apps/all"],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,14 +6,23 @@
       "name": "ui-oracle",
     },
     "apps/all": {
-      "name": "all-oracle-studio",
+      "name": "@soul-brews-studio/all-oracle-studio",
       "version": "0.1.0",
-      "dependencies": {
+      "bin": {
+        "all-oracle-studio": "./bin/serve.ts",
+      },
+      "devDependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@tailwindcss/vite": "^4.2.1",
+        "@types/bun": "^1.3.12",
+        "@types/node": "^24.10.1",
+        "@types/react": "^19.2.5",
+        "@types/react-dom": "^19.2.3",
         "@types/three": "^0.182.0",
         "@ui-oracle/shared-ui": "workspace:*",
+        "@vitejs/plugin-react": "^5.1.1",
         "knowledge-map-3d": "github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D",
         "ml5": "1",
         "react": "^19.2.0",
@@ -22,16 +31,8 @@
         "react-router-dom": "^7.11.0",
         "recharts": "^3.6.0",
         "remark-gfm": "^4.0.1",
-        "three": "^0.182.0",
-      },
-      "devDependencies": {
-        "@tailwindcss/vite": "^4.2.1",
-        "@types/bun": "^1.3.12",
-        "@types/node": "^24.10.1",
-        "@types/react": "^19.2.5",
-        "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^5.1.1",
         "tailwindcss": "^4.2.1",
+        "three": "^0.182.0",
         "typescript": "~5.9.3",
         "vite": "^7.2.4",
       },
@@ -427,6 +428,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
 
+    "@soul-brews-studio/all-oracle-studio": ["@soul-brews-studio/all-oracle-studio@workspace:apps/all"],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
@@ -606,8 +609,6 @@
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
-
-    "all-oracle-studio": ["all-oracle-studio@workspace:apps/all"],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -1453,6 +1454,8 @@
 
     "canvas-oracle-studio/@types/three": ["@types/three@0.184.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA=="],
 
+    "canvas-oracle-studio/knowledge-map-3d": ["knowledge-map-3d@github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D#4dfd12d", { "peerDependencies": { "react": ">=18", "react-dom": ">=18", "three": ">=0.150.0" } }, "Bombbaza-Multi-Planet-System-Knowledge-Map-3D-4dfd12d", "sha512-ddXFX0qW9mEd+3JaixN8wwGwsvaFKz0foCXz+ioPQug+s84lSfZGYdJUfyB+rSnpCcnf275WQhBOSR9JYxUIlg=="],
+
     "canvas-oracle-studio/three": ["three@0.184.0", "", {}, "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg=="],
 
     "d3-dsv/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
@@ -1470,6 +1473,8 @@
     "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "oracle-studio/knowledge-map-3d": ["knowledge-map-3d@github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D#4dfd12d", { "peerDependencies": { "react": ">=18", "react-dom": ">=18", "three": ">=0.150.0" } }, "Bombbaza-Multi-Planet-System-Knowledge-Map-3D-4dfd12d", "sha512-ddXFX0qW9mEd+3JaixN8wwGwsvaFKz0foCXz+ioPQug+s84lSfZGYdJUfyB+rSnpCcnf275WQhBOSR9JYxUIlg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 


### PR DESCRIPTION
Preps the combined hub for `bunx @soul-brews-studio/all-oracle-studio`.

- **Scoped name** `@soul-brews-studio/all-oracle-studio` + `publishConfig.access: public`
- **Zero runtime deps**: moved all build deps to `devDependencies`. The published artifact is `bin/` + `dist/` only — `serve.ts` uses just Node builtins + `Bun.serve`, and Vite already inlined react/three/shared-ui into `dist/`. So no `workspace:*` / unpublished `@ui-oracle/shared-ui` to 404 on install.
- Verified `npm pack --dry-run`: 5 files, ~758 kB (bin/serve.ts + dist/* + package.json).

After merge + `npm login`: `cd apps/all && bun publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)