### PR TITLE
fix(nav): one active section in the combined hub, not many

### DIFF
--- a/packages/shared-ui/src/components/AppHeader/MainNav.tsx
+++ b/packages/shared-ui/src/components/AppHeader/MainNav.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from 'react-router-dom';
 import type { CrossOriginResolver, NavItem } from './nav-types';
-import { isActiveNav } from './nav-types';
+import { isActiveInApp, isActiveNav } from './nav-types';
 import { NavDisclosure } from './NavDisclosure';
 
 interface MainNavProps {
@@ -38,10 +38,11 @@ export function MainNav({ items, crossOriginHref, combinedMode = false, inAppHre
             />
           );
         }
+        const to = inApp ? inApp(item) : item.path;
         // Combined bundle: never bounce cross-origin — stay in-app via inApp(item).
         const href = inApp ? null : crossOriginHref(item);
         const active = inApp
-          ? isActiveNav(location, item, { ignoreHostGate: true })
+          ? isActiveInApp(location.pathname, to)
           : isActiveNav(location, item);
         const cls = `px-2.5 py-1.5 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
           active
@@ -55,7 +56,6 @@ export function MainNav({ items, crossOriginHref, combinedMode = false, inAppHre
             </a>
           );
         }
-        const to = inApp ? inApp(item) : item.path;
         return (
           <Link key={item.path} to={to} className={cls} aria-current={active ? 'page' : undefined}>
             {item.label}

--- a/packages/shared-ui/src/components/AppHeader/NavDisclosure.tsx
+++ b/packages/shared-ui/src/components/AppHeader/NavDisclosure.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import type { CrossOriginResolver, NavItem } from './nav-types';
-import { isActiveNav } from './nav-types';
+import { isActiveInApp, isActiveNav } from './nav-types';
 
 interface NavDisclosureProps {
   item: NavItem;
@@ -41,11 +41,11 @@ export function NavDisclosure({ item, crossOriginHref, combinedMode = false, inA
   const parentHref = inApp ? null : crossOriginHref(item);
   const hasRealPath = item.path && item.path !== '#';
   const parentActive = inApp
-    ? isActiveNav(location, item, { ignoreHostGate: true })
+    ? isActiveInApp(location.pathname, inApp(item))
     : isActiveNav(location, item);
   const anyActive = parentActive
     || children.some((c) =>
-      inApp ? isActiveNav(location, c, { ignoreHostGate: true }) : isActiveNav(location, c),
+      inApp ? isActiveInApp(location.pathname, inApp(c)) : isActiveNav(location, c),
     );
 
   const labelClass = `px-2.5 py-1.5 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
@@ -115,7 +115,7 @@ export function NavDisclosure({ item, crossOriginHref, combinedMode = false, inA
             {children.map((child) => {
               const href = inApp ? null : crossOriginHref(child);
               const childActive = inApp
-                ? isActiveNav(location, child, { ignoreHostGate: true })
+                ? isActiveInApp(location.pathname, inApp(child))
                 : isActiveNav(location, child);
               const childClass = `block px-3 py-2 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
                 childActive

--- a/packages/shared-ui/src/components/AppHeader/ToolsDropdown.tsx
+++ b/packages/shared-ui/src/components/AppHeader/ToolsDropdown.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import type { CrossOriginResolver, NavItem } from './nav-types';
-import { isActiveNav } from './nav-types';
+import { isActiveInApp, isActiveNav } from './nav-types';
 
 interface ToolsDropdownProps {
   items: NavItem[];
@@ -26,7 +26,7 @@ export function ToolsDropdown({ items, crossOriginHref, label = 'Tools ▾', com
   const inApp = combinedMode && inAppHref ? inAppHref : undefined;
 
   const anyActive = items.some((t) =>
-    inApp ? isActiveNav(location, t, { ignoreHostGate: true }) : isActiveNav(location, t),
+    inApp ? isActiveInApp(location.pathname, inApp(t)) : isActiveNav(location, t),
   );
 
   return (
@@ -59,7 +59,7 @@ export function ToolsDropdown({ items, crossOriginHref, label = 'Tools ▾', com
           // Combined bundle: never bounce cross-origin — stay in-app via inApp(item).
           const href = inApp ? null : crossOriginHref(item);
           const active = inApp
-            ? isActiveNav(location, item, { ignoreHostGate: true })
+            ? isActiveInApp(location.pathname, inApp(item))
             : isActiveNav(location, item);
           const cls = `block px-3 py-2 rounded-lg text-[13px] whitespace-nowrap transition-all duration-150 ${
             active

--- a/packages/shared-ui/src/components/AppHeader/nav-types.ts
+++ b/packages/shared-ui/src/components/AppHeader/nav-types.ts
@@ -64,6 +64,20 @@ export function isActiveNav(
   return true;
 }
 
+/**
+ * Active-state for combined single-origin bundles. Compares the current pathname
+ * to an item's ALREADY-RESOLVED in-app href (the app's inAppHref output), which is
+ * section-aware: active on the section's own path and any sub-path. The root ("/")
+ * is active ONLY on an exact "/", so studio-at-root doesn't light up every sibling
+ * whose menu `path` is "/" (Feed/Forum/Canvas/Schedule/Vector all carry path "/").
+ */
+export function isActiveInApp(pathname: string, resolvedHref: string): boolean {
+  const target = resolvedHref.split('?')[0].replace(/\/+$/, '') || '/';
+  const cur = pathname.replace(/\/+$/, '') || '/';
+  if (target === '/' || target === '#') return cur === target;
+  return cur === target || cur.startsWith(target + '/');
+}
+
 type OrderedNavItem = NavItem & { order: number };
 
 export function buildNavSet(items: MenuApiItem[]): NavSet {


### PR DESCRIPTION
Fixes the **"many menu actives"** bug: at `/`, six nav items lit up (Overview, Feed, Forum, Canvas, Schedule, Vector) because the active check compared `location.pathname` to the raw `item.path` — and studio-at-root puts all of those at menu path `/`.

New `isActiveInApp(pathname, resolvedHref)` is section-aware (root active only on exact `/`, sections active on their prefix) and compares against the **resolved** `inAppHref` in `MainNav`/`ToolsDropdown`/`NavDisclosure`.

**Browser-verified** (dev-browser): `/` → only **Overview** active; clicking **Feed** → `/feed/`, only Feed active, Knowledge Feed page renders. Deployed live (Version 37f62195).

🤖 Generated with [Claude Code](https://claude.com/claude-code)