### PR TITLE
fix(combined): cross-app doc links broke after studio-at-root

### DIFF
--- a/apps/canvas/src/plugins/react/MapPlugin.tsx
+++ b/apps/canvas/src/plugins/react/MapPlugin.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { KnowledgeMap } from 'knowledge-map-3d';
-import { useBase, useNavTo, withBase } from '@ui-oracle/shared-ui';
+import { useNavigate } from 'react-router-dom';
+import { useBase } from '@ui-oracle/shared-ui';
 import { usePlanetsData } from '../../hooks/usePlanetsData';
 import { usePlanetsSearch } from '../../hooks/usePlanetsSearch';
 import { PlanetsLoading, PlanetsEmpty } from '../../components/planets/PlanetsEmpty';
@@ -11,7 +12,7 @@ export function MapPlugin() {
   const data = usePlanetsData();
   const search = usePlanetsSearch();
   const base = useBase();
-  const navigate = useNavTo();
+  const navigate = useNavigate();
   const [visibleTypes, setVisibleTypes] = useState<Set<string>>(() => new Set(Object.keys(TYPE_COLORS)));
 
   const filteredDocs = useMemo(
@@ -40,7 +41,8 @@ export function MapPlugin() {
         highlightIds={search.matchIds}
         onDocumentClick={(doc) => {
           if (base) {
-            navigate(withBase(base, `/studio/doc/${encodeURIComponent(doc.id)}`));
+            // Combined bundle: studio's doc viewer is at the root /doc/:id.
+            navigate(`/doc/${encodeURIComponent(doc.id)}`);
           } else {
             window.location.href = `/doc/${encodeURIComponent(doc.id)}`;
           }

--- a/apps/canvas/src/plugins/react/PlanetsPlugin.tsx
+++ b/apps/canvas/src/plugins/react/PlanetsPlugin.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useBase, useNavTo, withBase } from '@ui-oracle/shared-ui';
+import { useNavigate } from 'react-router-dom';
+import { useBase } from '@ui-oracle/shared-ui';
 import { usePlanetsData } from '../../hooks/usePlanetsData';
 import { usePlanetsSearch } from '../../hooks/usePlanetsSearch';
 import { PlanetsCanvas } from '../../components/planets/PlanetsCanvas';
@@ -13,7 +14,7 @@ export function PlanetsPlugin() {
   const data = usePlanetsData();
   const search = usePlanetsSearch();
   const base = useBase();
-  const navigate = useNavTo();
+  const navigate = useNavigate();
   const [visibleTypes, setVisibleTypes] = useState<Set<string>>(() => new Set(Object.keys(TYPE_COLORS)));
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
 
@@ -54,7 +55,8 @@ export function PlanetsPlugin() {
           highlightIds={search.matchIds}
           onDocumentClick={(doc) => {
             if (base) {
-              navigate(withBase(base, `/studio/doc/${encodeURIComponent(doc.id)}`));
+              // Combined bundle: studio's doc viewer is at the root /doc/:id.
+              navigate(`/doc/${encodeURIComponent(doc.id)}`);
             } else {
               window.location.href = `/doc/${encodeURIComponent(doc.id)}`;
             }

--- a/apps/feed/src/pages/DocRedirect.tsx
+++ b/apps/feed/src/pages/DocRedirect.tsx
@@ -1,27 +1,29 @@
 import { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { useBase, withBase, useNavTo } from '@ui-oracle/shared-ui';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useBase } from '@ui-oracle/shared-ui';
 
 const STUDIO_ORIGIN = 'https://studio.buildwithoracle.com';
 
 export function DocRedirect() {
   const { id } = useParams<{ id: string }>();
   const base = useBase();
-  const navigate = useNavTo();
+  // Raw navigate (NOT base-aware): the doc viewer (studio) is mounted at the
+  // combined-bundle ROOT, so the in-app target is the top-level /doc/:id — not
+  // base-prefixed (would double to /feed/doc) and not /studio/* (studio is root).
+  const navigate = useNavigate();
   useEffect(() => {
-    if (id) {
-      if (base) {
-        // Combined mode: studio is mounted in the same bundle — navigate in-app.
-        navigate(withBase(base, `/studio/doc/${id}`), { replace: true });
-      } else {
-        // Standalone: hard-redirect to the studio subdomain.
-        window.location.replace(`${STUDIO_ORIGIN}/doc/${id}`);
-      }
+    if (!id) return;
+    if (base) {
+      // Combined bundle: studio's doc viewer lives at the root.
+      navigate(`/doc/${id}`, { replace: true });
+    } else {
+      // Standalone feed: hard-redirect to the studio subdomain.
+      window.location.replace(`${STUDIO_ORIGIN}/doc/${id}`);
     }
   }, [id, base, navigate]);
   return (
     <div className="max-w-[1300px] mx-auto py-10 px-6 text-text-secondary">
-      <p className="text-sm">Redirecting to <a className="text-accent underline" href={STUDIO_ORIGIN}>studio</a>…</p>
+      <p className="text-sm">Opening document…</p>
     </div>
   );
 }


### PR DESCRIPTION
Clicking a **feed card** (or canvas map/planet node) navigated to a mangled `/feed/feed/studio/doc/:id` and rendered nothing — "can't click anything."

**Root cause:** `DocRedirect` + canvas plugins called `navigate(withBase(base, '/studio/doc/:id'))` where `navigate` was already the base-aware `useNavTo` → base applied **twice**, plus the stale `/studio/*` prefix (studio is now the bundle root).

**Fix:** raw `useNavigate` → top-level `/doc/:id` (studio's doc viewer at root). Standalone cross-origin redirect unchanged.

**Browser-verified** (dev-browser): feed card → `/doc/:id`, document renders. Deployed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)