### PR TITLE
chore(all): Dockerfile for the combined hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Deps + build artifacts — reinstalled / rebuilt inside the image
+node_modules
+**/node_modules
+**/dist
+**/.wrangler
+**/.tmp
+**/*.tsbuildinfo
+
+# VCS + editor + OS
+.git
+.github
+**/.DS_Store
+**/*.log
+
+# Oracle vault / memory — not needed for the build
+"ψ"
+ψ
+
+# Misc
+**/.env
+**/.env.*

--- a/apps/all/Dockerfile
+++ b/apps/all/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+#
+# ARRA 🔮Racle — combined Oracle hub, containerized.
+# apps/all imports every app's source (../../studio/src, …), so build from the
+# REPO ROOT as context:
+#
+#   docker build -f apps/all/Dockerfile -t arra-oracle-studio .
+#   docker run --rm -p 3000:3000 \
+#     -e ORACLE_API_URL=http://host.docker.internal:47778 \
+#     arra-oracle-studio
+#
+# (On Linux add: --add-host=host.docker.internal:host-gateway)
+# Open http://localhost:3000 — studio at /, satellites at /vector, /feed, …
+
+# ---- builder: install the workspace + build the combined Vite bundle ----
+FROM oven/bun:1 AS builder
+WORKDIR /repo
+COPY . .
+RUN bun install --frozen-lockfile
+RUN bun run --filter '@soul-brews-studio/arra-oracle-studio' build
+
+# ---- runtime: slim image — just the built dist/, the serve script, and Bun ----
+# The published artifact is self-contained (Vite inlined react/three/shared-ui
+# into dist/), and bin/serve.ts uses only Node builtins (fs/path) + Bun.serve,
+# so the runtime needs ZERO npm install.
+FROM oven/bun:1-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production \
+    PORT=3000 \
+    ORACLE_API_URL=http://localhost:47778
+COPY --from=builder /repo/apps/all/dist ./dist
+COPY --from=builder /repo/apps/all/bin ./bin
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD bun -e "fetch('http://localhost:'+(process.env.PORT||3000)+'/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+CMD ["bun", "bin/serve.ts"]

--- a/apps/all/bin/serve.ts
+++ b/apps/all/bin/serve.ts
@@ -36,8 +36,9 @@ Options:
   process.exit(0);
 }
 
-const PORT = parseInt(getArg('--port', '3000'), 10);
-const API_URL = getArg('--api', 'http://localhost:47778');
+// Flags win; then env (PORT / ORACLE_API_URL — 12-factor + Docker friendly); then defaults.
+const PORT = parseInt(getArg('--port', process.env.PORT || '3000'), 10);
+const API_URL = getArg('--api', process.env.ORACLE_API_URL || 'http://localhost:47778');
 const DIST = join(import.meta.dirname, '..', 'dist');
 
 if (!existsSync(DIST)) {


### PR DESCRIPTION
Containerizes **`apps/all`** (the ARRA Oracle combined bundle) as a self-contained static server.

## Files
- **`apps/all/Dockerfile`** — multi-stage:
  - *Builder* (`oven/bun:1`): copies the whole monorepo (needed — `apps/all` imports `../../studio/src`, etc.), `bun install --frozen-lockfile`, builds the combined Vite bundle.
  - *Runtime* (`oven/bun:1-slim`): only `dist/` + `bin/serve.ts` → **zero runtime deps** (Vite inlined react/three/shared-ui; `serve.ts` uses only Bun + `fs/path`). `HEALTHCHECK` + `EXPOSE 3000`.
- **`bin/serve.ts`**: reads `PORT` / `ORACLE_API_URL` env (flags still win) so the container is configurable.
- **`.dockerignore`**: keeps `node_modules`/`dist`/`.git`/`ψ` out of the build context.

## Use
```bash
docker build -f apps/all/Dockerfile -t arra-oracle-studio .
docker run --rm -p 3000:3000 -e ORACLE_API_URL=http://host.docker.internal:47778 arra-oracle-studio
# → http://localhost:3000  (studio at /, satellites at /vector, /feed, …)
```
The `/api` proxy runs server-side in the container, so the browser only hits `localhost:3000` — no CORS/PNA, fully live.

## ⚠️ Not yet image-tested
Local Docker daemon was down, so the image hasn't been built end-to-end. The builder runs the same `bun run --filter @soul-brews-studio/arra-oracle-studio build` verified all session, and the `serve.ts` env change is confirmed (PORT honored). Recommend a test build before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)