### PR TITLE
fix(all): mirror studio CSS into combined bundle + speed up Map hover

### DIFF
--- a/apps/all/src/index.css
+++ b/apps/all/src/index.css
@@ -48,6 +48,115 @@ body {
 ::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.2); }
 * { scrollbar-width: thin; scrollbar-color: rgba(255, 255, 255, 0.1) transparent; }
 
+/* ───────────────────────────────────────────────────────────────────────────
+ * Studio custom CSS — MIRRORED from apps/studio/src/index.css.
+ * These are hand-written rules Tailwind's @source scan cannot generate
+ * (imperatively-managed elements, CSS modules, keyframes). Keep in sync:
+ * if you add a non-utility rule to studio's index.css, mirror it here or the
+ * combined bundle renders it unstyled. (This is why Map labels piled top-left:
+ * .proximity-label was missing → labels lost `position: absolute`.)
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+/* Legacy CSS variable bridge — LogCard.module.css et al. use these names */
+:root {
+  --bg-primary: #0a0a0f;
+  --bg-secondary: #0f0f1a;
+  --bg-card: #0f0f14;
+  --border: rgba(255, 255, 255, 0.08);
+  --text-primary: #e0e0e0;
+  --text-secondary: #888;
+  --text-muted: #666;
+  --accent: #64b5f6;
+  --accent-hover: #42a5f5;
+  --success: #4ade80;
+  --warning: #fbbf24;
+}
+
+/* Prose styles for rendered Markdown (Handoff page) */
+.prose-handoff h1,
+.prose-handoff h2,
+.prose-handoff h3 {
+  margin: 16px 0 8px;
+  color: var(--text-primary);
+}
+.prose-handoff h1 { font-size: 20px; }
+.prose-handoff h2 { font-size: 17px; }
+.prose-handoff h3 { font-size: 15px; }
+.prose-handoff p { margin: 8px 0; }
+.prose-handoff ul,
+.prose-handoff ol { margin: 8px 0; padding-left: 24px; }
+.prose-handoff li { margin: 4px 0; }
+.prose-handoff code {
+  background: var(--bg-secondary);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+}
+.prose-handoff pre {
+  background: var(--bg-secondary);
+  padding: 16px;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.prose-handoff pre code { background: none; padding: 0; }
+.prose-handoff hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 16px 0;
+}
+.prose-handoff strong { color: var(--accent); }
+
+/* Proximity labels for Map 3D view (imperatively managed → not Tailwind-scannable) */
+.proximity-label {
+  position: absolute;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  text-shadow: 0 0 8px rgba(0, 0, 0, 1), 0 1px 3px rgba(0, 0, 0, 0.9);
+  transition: opacity 0.15s ease-out;
+  pointer-events: none;
+  letter-spacing: 0.3px;
+}
+
+/* Pulsing dot animation for Map search indicator */
+@keyframes search-pulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+.animate-search-pulse {
+  animation: search-pulse 1s infinite;
+}
+
+/* HUD slider styles (Graph / Graph3D) */
+.hud-slider {
+  width: 100%;
+  margin-top: 4px;
+  height: 4px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: #333;
+  border-radius: 2px;
+  outline: none;
+}
+.hud-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 12px;
+  height: 12px;
+  background: #a78bfa;
+  border-radius: 50%;
+  cursor: pointer;
+}
+.hud-slider::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  background: #a78bfa;
+  border-radius: 50%;
+  cursor: pointer;
+  border: none;
+}
+
 /* Playground animations */
 @keyframes gradientShift {
   0%, 100% { background-position: 0% 50%; }

--- a/apps/studio/src/components/BackendGate.tsx
+++ b/apps/studio/src/components/BackendGate.tsx
@@ -87,7 +87,7 @@ function UnreachableLanding({ onRetry }: { onRetry: () => void }) {
           />
           <InstallCard
             label="3. Studio (this UI, served locally)"
-            command="bunx @soul-brews-studio/oracle-studio"
+            command="bunx @soul-brews-studio/arra-oracle-studio"
           />
         </div>
 

--- a/apps/studio/src/pages/Map.tsx
+++ b/apps/studio/src/pages/Map.tsx
@@ -318,6 +318,7 @@ export function Map() {
     function onMouseDown(e: MouseEvent) {
       isDragging.current = true;
       dragStart.current = { x: e.clientX, y: e.clientY };
+      container!.style.cursor = 'grabbing';
     }
 
     function onMouseUp(e: MouseEvent) {
@@ -337,6 +338,7 @@ export function Map() {
         }
       }
       isDragging.current = false;
+      container!.style.cursor = 'grab';
     }
 
     function onMouseMove(e: MouseEvent) {
@@ -349,22 +351,11 @@ export function Map() {
         const dy = e.clientY - dragStart.current.y;
         targetAngleX.current = camAngleX.current.x + dx * 0.005;
         targetAngleY.current = Math.max(-1.2, Math.min(1.2, camAngleY.current.x - dy * 0.005));
-        return;
       }
-
-      mouse.x = mouseNDC.current.x;
-      mouse.y = mouseNDC.current.y;
-      raycaster.setFromCamera(mouse, camera);
-      const intersects = raycaster.intersectObjects(meshes);
-
-      if (intersects.length > 0) {
-        const doc = intersects[0].object.userData.doc as MapDocument;
-        setHoveredDoc(doc);
-        container!.style.cursor = 'pointer';
-      } else {
-        setHoveredDoc(null);
-        container!.style.cursor = isDragging.current ? 'grabbing' : 'grab';
-      }
+      // NOTE: hover detection (which dot is under the cursor) is derived in the
+      // animation loop from the node projections it already computes each frame.
+      // Raycasting all ~2,900 meshes on every mousemove (100+/s on a fast mouse)
+      // was the cause of the hover-while-turning lag.
     }
 
     function onWheel(e: WheelEvent) {
@@ -434,6 +425,10 @@ export function Map() {
     const dt = 1 / 60;
     const tempVec = new THREE.Vector3();
     const aspectRatio = width / height;
+    // Hover is derived in-loop (no per-mousemove raycast). Only push to React
+    // when the dot under the cursor actually changes.
+    let lastHoverId: string | null = null;
+    const HOVER_DIST = 0.025; // screen-space radius treated as "cursor on this dot"
 
     function animate() {
       time += 0.016;
@@ -578,6 +573,19 @@ export function Map() {
           el.style.display = '';
         } else {
           el.style.display = 'none';
+        }
+      }
+
+      // Derive hover from the nearest projected node (reuses the work above —
+      // no raycast). Push to React state + cursor only on change.
+      if (!isDragging.current) {
+        const top = nearby.length > 0 ? nearby[0] : null;
+        const hoverDoc = top && top.screenDist < HOVER_DIST ? top.doc : null;
+        const hoverId = hoverDoc ? hoverDoc.id : null;
+        if (hoverId !== lastHoverId) {
+          lastHoverId = hoverId;
+          setHoveredDoc(hoverDoc);
+          container!.style.cursor = hoverDoc ? 'pointer' : 'grab';
         }
       }
 


### PR DESCRIPTION
## What & why

Three fixes to the combined bundle (`apps/all`) surfaced while running it locally at `localhost:3000`.

### 1. Map labels piled in the top-left (combined-bundle only)
`.proximity-label` is defined in `apps/studio/src/index.css` but was never mirrored into the combined bundle's CSS (`0` matches in the built combined CSS vs `1` in studio's). Without it the Map's hover labels lost `position: absolute` and collapsed into normal document flow, stacking in the top-left corner.

Mirrored **all** of studio's hand-written CSS into `apps/all/src/index.css` — it was missing five groups, not one:

| Rule | Affects |
|---|---|
| `.proximity-label` | Map hover labels (the reported bug) |
| `:root` legacy vars (`--accent`…) | `LogCard.module.css` + other CSS modules (12× `--accent`) |
| `.prose-handoff` | Handoff markdown page |
| `.hud-slider` | Graph / Graph3D sliders |
| `.animate-search-pulse` + keyframes | Map search indicator |

Added a sync-note comment so the gap can't silently reopen.

### 2. Hover lag while the globe rotates
`onMouseMove` raycast **all ~2,869 dot meshes on every mouse event** (100+/s on a fast mouse), on top of the per-frame animation loop. Removed it — hover is now derived from the node projections the animation loop already computes each frame, and only pushed to React state on hover-change. Click still uses a precise raycast (once per click).

### 3. BackendGate landing command
The studio install command referenced a nonexistent package (`@soul-brews-studio/oracle-studio`); corrected to the real name `@soul-brews-studio/arra-oracle-studio`.

## Test
Hard-reload `localhost:3000/map`, hover the globe while it auto-rotates: labels track the dots under the cursor and the lag is gone. Confirmed visually by @nazt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)